### PR TITLE
feat: improve trace sidepanel waterfall view

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "@t3-oss/env-core": "^0.13.8",
     "@t3-oss/env-nextjs": "^0.13.8",
     "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-virtual": "^3.13.12",
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",
     "@trpc/server": "^11.0.0",

--- a/apps/web/src/components/traces/span-detail-sidebar.tsx
+++ b/apps/web/src/components/traces/span-detail-sidebar.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { X, ChevronDown, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { SpanJsonViewer } from "./span-json-viewer";
+import { SPAN_TYPE_CONFIG, SPAN_LEVEL_COLORS } from "./span-type-config";
+import { inferSpanType } from "@/lib/traces/infer-span-type";
+import { cn } from "@/lib/utils";
+import { formatDuration } from "@/lib/format";
+import { useSpanDetail } from "@/hooks/traces/use-span-detail";
+import type { SpanLevel } from "@/lib/traces/types";
+
+interface SpanDetailSidebarProps {
+  workspaceSlug: string;
+  projectId: string;
+  traceId: string;
+  spanId: string;
+  onClose: () => void;
+}
+
+const formatTime = (iso: string): string => {
+  return new Date(iso).toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    fractionalSecondDigits: 3,
+  });
+};
+
+/**
+ * Sidebar panel showing full span details.
+ * Lazy loads input/output/metadata on render.
+ */
+export function SpanDetailSidebar({
+  workspaceSlug,
+  projectId,
+  traceId,
+  spanId,
+  onClose,
+}: SpanDetailSidebarProps) {
+  const { span, isLoading, error } = useSpanDetail({
+    workspaceSlug,
+    projectId,
+    traceId,
+    spanId,
+  });
+
+  if (error) {
+    return (
+      <div className="flex flex-col h-full border-l w-[400px]">
+        <SidebarHeader onClose={onClose} />
+        <div className="flex items-center justify-center flex-1 text-destructive">
+          Failed to load span details
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading || !span) {
+    return (
+      <div className="flex flex-col h-full border-l w-[400px]">
+        <SidebarHeader onClose={onClose} />
+        <SpanDetailSkeleton />
+      </div>
+    );
+  }
+
+  const spanType = inferSpanType(span);
+  const typeConfig = SPAN_TYPE_CONFIG[spanType];
+  const TypeIcon = typeConfig.icon;
+  const level = span.level as SpanLevel;
+
+  return (
+    <div className="flex flex-col h-full border-l w-[400px]">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b flex-shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <TypeIcon className={cn("h-5 w-5 flex-shrink-0", typeConfig.color)} />
+          <span className="font-semibold truncate" title={span.name}>
+            {span.name}
+          </span>
+        </div>
+        <Button variant="ghost" size="icon" onClick={onClose} className="flex-shrink-0">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Content */}
+      <ScrollArea className="flex-1">
+        <div className="p-4 space-y-6">
+          {/* Badges */}
+          <div className="flex flex-wrap gap-2">
+            <Badge className={cn(SPAN_LEVEL_COLORS[level], "text-white")}>
+              {level}
+            </Badge>
+            <Badge variant="outline" className={typeConfig.bgColor}>
+              {typeConfig.label}
+            </Badge>
+            {span.model && <Badge variant="secondary">{span.model}</Badge>}
+          </div>
+
+          {/* Status Message (if error/warning) */}
+          {span.statusMessage && (
+            <div
+              className={cn(
+                "p-3 rounded-lg text-sm",
+                level === "ERROR"
+                  ? "bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800"
+                  : "bg-yellow-100 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800"
+              )}
+            >
+              {span.statusMessage}
+            </div>
+          )}
+
+          {/* Timing */}
+          <Section title="Timing">
+            <InfoRow label="Start" value={formatTime(span.startTime)} />
+            {span.endTime && <InfoRow label="End" value={formatTime(span.endTime)} />}
+            <InfoRow
+              label="Duration"
+              value={span.duration !== null ? formatDuration(span.duration) : "Running..."}
+              mono
+            />
+          </Section>
+
+          {/* Token Usage (LLM only) */}
+          {span.totalTokens && (
+            <Section title="Token Usage">
+              <InfoRow
+                label="Prompt"
+                value={span.promptTokens?.toLocaleString() ?? "-"}
+              />
+              <InfoRow
+                label="Completion"
+                value={span.completionTokens?.toLocaleString() ?? "-"}
+              />
+              <InfoRow
+                label="Total"
+                value={span.totalTokens.toLocaleString()}
+                mono
+              />
+            </Section>
+          )}
+
+          {/* Input */}
+          {span.input !== null && span.input !== undefined && (
+            <CollapsibleSection title="Input" defaultOpen>
+              <SpanJsonViewer data={span.input} />
+            </CollapsibleSection>
+          )}
+
+          {/* Output */}
+          {span.output !== null && span.output !== undefined && (
+            <CollapsibleSection title="Output" defaultOpen>
+              <SpanJsonViewer data={span.output} />
+            </CollapsibleSection>
+          )}
+
+          {/* Model Parameters (LLM) */}
+          {span.modelParameters !== null && span.modelParameters !== undefined && (
+            <CollapsibleSection title="Model Parameters">
+              <SpanJsonViewer data={span.modelParameters} />
+            </CollapsibleSection>
+          )}
+
+          {/* Metadata */}
+          {span.metadata !== null && span.metadata !== undefined && (
+            <CollapsibleSection title="Metadata">
+              <SpanJsonViewer data={span.metadata} />
+            </CollapsibleSection>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function SidebarHeader({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="flex items-center justify-between p-4 border-b flex-shrink-0">
+      <span className="font-semibold">Span Details</span>
+      <Button variant="ghost" size="icon" onClick={onClose}>
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h4 className="text-sm font-medium mb-2">{title}</h4>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function InfoRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string | number | undefined | null;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex justify-between text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className={mono ? "font-mono" : ""}>{value ?? "-"}</span>
+    </div>
+  );
+}
+
+function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return (
+    <div>
+      <button
+        className="flex items-center gap-2 text-sm font-medium mb-2 hover:text-foreground"
+        onClick={handleToggle}
+      >
+        {isOpen ? (
+          <ChevronDown className="h-4 w-4" />
+        ) : (
+          <ChevronRight className="h-4 w-4" />
+        )}
+        {title}
+      </button>
+      {isOpen && children}
+    </div>
+  );
+}
+
+function SpanDetailSkeleton() {
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex gap-2">
+        <Skeleton className="h-6 w-16" />
+        <Skeleton className="h-6 w-20" />
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-4 w-28" />
+      </div>
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/components/traces/span-json-viewer.tsx
+++ b/apps/web/src/components/traces/span-json-viewer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Check, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface SpanJsonViewerProps {
+  data: unknown;
+  maxHeight?: number;
+}
+
+/**
+ * Pretty-printed JSON viewer with copy button.
+ */
+export function SpanJsonViewer({ data, maxHeight = 300 }: SpanJsonViewerProps) {
+  const [copied, setCopied] = useState(false);
+
+  const jsonString = JSON.stringify(data, null, 2);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(jsonString);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [jsonString]);
+
+  return (
+    <div className="relative group">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute top-2 right-2 h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+        onClick={handleCopy}
+      >
+        {copied ? (
+          <Check className="h-4 w-4 text-green-500" />
+        ) : (
+          <Copy className="h-4 w-4" />
+        )}
+      </Button>
+
+      <pre
+        className={cn(
+          "p-4 rounded-lg bg-muted overflow-auto text-xs font-mono",
+          "whitespace-pre-wrap break-words"
+        )}
+        style={{ maxHeight }}
+      >
+        <code>{jsonString}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/traces/span-type-config.ts
+++ b/apps/web/src/components/traces/span-type-config.ts
@@ -1,0 +1,79 @@
+import {
+  Sparkles,
+  FileText,
+  Code,
+  Globe,
+  Database,
+  Box,
+  type LucideIcon,
+} from "lucide-react";
+import type { SpanType, SpanLevel } from "@/lib/traces/types";
+
+interface SpanTypeConfig {
+  icon: LucideIcon;
+  color: string;
+  bgColor: string;
+  label: string;
+}
+
+/**
+ * Visual configuration for each span type.
+ */
+export const SPAN_TYPE_CONFIG: Record<SpanType, SpanTypeConfig> = {
+  LLM: {
+    icon: Sparkles,
+    color: "text-purple-500",
+    bgColor: "bg-purple-100 dark:bg-purple-900/30",
+    label: "LLM",
+  },
+  LOG: {
+    icon: FileText,
+    color: "text-gray-500",
+    bgColor: "bg-gray-100 dark:bg-gray-800",
+    label: "Log",
+  },
+  FUNCTION: {
+    icon: Code,
+    color: "text-blue-500",
+    bgColor: "bg-blue-100 dark:bg-blue-900/30",
+    label: "Function",
+  },
+  HTTP: {
+    icon: Globe,
+    color: "text-green-500",
+    bgColor: "bg-green-100 dark:bg-green-900/30",
+    label: "HTTP",
+  },
+  DB: {
+    icon: Database,
+    color: "text-orange-500",
+    bgColor: "bg-orange-100 dark:bg-orange-900/30",
+    label: "Database",
+  },
+  CUSTOM: {
+    icon: Box,
+    color: "text-slate-500",
+    bgColor: "bg-slate-100 dark:bg-slate-800",
+    label: "Custom",
+  },
+};
+
+/**
+ * Timeline bar colors based on span level.
+ */
+export const SPAN_LEVEL_COLORS: Record<SpanLevel, string> = {
+  DEBUG: "bg-gray-400 dark:bg-gray-600",
+  DEFAULT: "bg-blue-500 dark:bg-blue-600",
+  WARNING: "bg-yellow-500 dark:bg-yellow-600",
+  ERROR: "bg-red-500 dark:bg-red-600",
+};
+
+/**
+ * Left border accent for timeline bars.
+ */
+export const SPAN_LEVEL_BORDER: Record<SpanLevel, string> = {
+  DEBUG: "border-l-gray-500",
+  DEFAULT: "border-l-blue-600",
+  WARNING: "border-l-yellow-600",
+  ERROR: "border-l-red-600",
+};

--- a/apps/web/src/components/traces/trace-detail-panel.tsx
+++ b/apps/web/src/components/traces/trace-detail-panel.tsx
@@ -1,16 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
-import {
-  Activity,
-  AlertCircle,
-  AlertTriangle,
-  ChevronDown,
-  ChevronUp,
-  Copy,
-  Check,
-  Cpu,
-} from "lucide-react";
+import { useCallback, useState } from "react";
+import { Activity, AlertCircle, AlertTriangle, Cpu, RefreshCw } from "lucide-react";
 import { format } from "date-fns";
 import {
   Sheet,
@@ -18,14 +9,14 @@ import {
   SheetTitle,
   SheetDescription,
 } from "@/components/ui/sheet";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { trpc } from "@/lib/trpc/client";
 import { formatDuration, formatTokens } from "@/lib/format";
-import type { SpanItem } from "@cognobserve/api/client";
+import { useTraceDetail } from "@/hooks/traces/use-trace-detail";
+import { TraceWaterfall } from "./trace-waterfall";
+import { SpanDetailSidebar } from "./span-detail-sidebar";
 
 interface TraceDetailPanelProps {
   workspaceSlug: string;
@@ -34,101 +25,52 @@ interface TraceDetailPanelProps {
   onClose: () => void;
 }
 
-// Helper function for span duration (start/end times)
-const formatSpanDuration = (startTime: string, endTime: string | null): string => {
-  if (!endTime) return "Running...";
-  const ms = new Date(endTime).getTime() - new Date(startTime).getTime();
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(2)}s`;
-  return `${(ms / 60000).toFixed(2)}m`;
-};
-
-const getSpanStatus = (span: SpanItem): { label: string; variant: "default" | "secondary" | "outline" | "destructive" } => {
-  if (span.level === "ERROR") return { label: "Error", variant: "destructive" };
-  if (span.level === "WARNING") return { label: "Warning", variant: "secondary" };
-  if (!span.endTime) return { label: "In Progress", variant: "outline" };
-  return { label: "Finished", variant: "default" };
-};
-
-// Reusable copy button component
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, [text]);
-
-  return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-5 w-5"
-      onClick={handleCopy}
-    >
-      {copied ? (
-        <Check className="h-3 w-3 text-green-500" />
-      ) : (
-        <Copy className="h-3 w-3 text-muted-foreground" />
-      )}
-    </Button>
-  );
-}
-
+/**
+ * Sheet panel showing trace details with waterfall visualization.
+ * Supports 500+ spans with virtualization.
+ */
 export function TraceDetailPanel({
   workspaceSlug,
   projectId,
   traceId,
   onClose,
 }: TraceDetailPanelProps) {
-  const { data: trace, isLoading } = trpc.traces.get.useQuery(
-    { workspaceSlug, projectId, traceId: traceId! },
-    { enabled: !!traceId }
-  );
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
+
+  const { trace, spanTree, stats, isLoading, error, refetch } = useTraceDetail({
+    workspaceSlug,
+    projectId,
+    traceId,
+  });
 
   const isOpen = traceId !== null;
 
-  // Calculate trace-level stats
-  const traceStats = useMemo(() => {
-    if (!trace) return null;
+  const handleRetry = useCallback(() => {
+    refetch();
+  }, [refetch]);
 
-    const spans = trace.spans;
-    const totalTokens = spans.reduce((sum, s) => sum + (s.totalTokens ?? 0), 0);
-    const hasErrors = spans.some((s) => s.level === "ERROR");
-    const hasWarnings = spans.some((s) => s.level === "WARNING");
-
-    let duration: number | null = null;
-    if (spans.length > 0) {
-      const startTimes = spans.map((s) => new Date(s.startTime).getTime());
-      const endTimes = spans.filter((s) => s.endTime).map((s) => new Date(s.endTime!).getTime());
-      if (endTimes.length > 0) {
-        duration = Math.max(...endTimes) - Math.min(...startTimes);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setSelectedSpanId(null);
+        onClose();
       }
-    }
+    },
+    [onClose]
+  );
 
-    // Find primary model
-    const modelCounts = spans
-      .filter((s) => s.model)
-      .reduce((acc, s) => {
-        acc[s.model!] = (acc[s.model!] || 0) + 1;
-        return acc;
-      }, {} as Record<string, number>);
-    const primaryModel = Object.entries(modelCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+  const handleSpanSelect = useCallback((spanId: string) => {
+    setSelectedSpanId(spanId);
+  }, []);
 
-    return { totalTokens, hasErrors, hasWarnings, duration, primaryModel, spanCount: spans.length };
-  }, [trace]);
-
-  const handleOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      onClose();
-    }
-  }, [onClose]);
+  const handleCloseSidebar = useCallback(() => {
+    setSelectedSpanId(null);
+  }, []);
 
   return (
     <Sheet open={isOpen} onOpenChange={handleOpenChange}>
-      <SheetContent className="w-full sm:max-w-3xl md:max-w-4xl lg:max-w-5xl xl:max-w-6xl p-0 flex flex-col overflow-hidden">
-        {/* Accessibility: Hidden title and description for screen readers */}
+      <SheetContent className="w-full sm:max-w-4xl lg:max-w-6xl p-0 flex flex-col overflow-hidden">
+        {/* Accessibility */}
         <SheetTitle className="sr-only">
           {trace?.name ?? "Trace Details"}
         </SheetTitle>
@@ -136,12 +78,14 @@ export function TraceDetailPanel({
           Detailed view of trace execution including spans, timing, and token usage
         </SheetDescription>
 
-        {isLoading || !trace ? (
+        {error ? (
+          <TraceDetailError error={error} onRetry={handleRetry} />
+        ) : isLoading || !trace ? (
           <TraceDetailSkeleton />
         ) : (
-          <>
+          <div className="flex flex-col h-full">
             {/* Header */}
-            <div className="px-6 pt-6 pb-4 flex-shrink-0">
+            <div className="px-6 pt-6 pb-4 flex-shrink-0 border-b">
               {/* Top label */}
               <div className="flex items-center gap-2 text-muted-foreground mb-3">
                 <Activity className="h-4 w-4" />
@@ -151,298 +95,113 @@ export function TraceDetailPanel({
               {/* Title */}
               <h2 className="text-2xl font-semibold mb-2 flex items-center gap-2">
                 {trace.name}
-                {traceStats?.hasErrors && (
+                {stats?.hasErrors && (
                   <AlertCircle className="h-5 w-5 text-destructive" />
                 )}
-                {traceStats?.hasWarnings && !traceStats?.hasErrors && (
+                {stats?.hasWarnings && !stats?.hasErrors && (
                   <AlertTriangle className="h-5 w-5 text-yellow-500" />
                 )}
               </h2>
 
-              {/* Trace ID */}
-              <div className="flex items-center gap-2 mb-4">
-                <span className="text-xs text-muted-foreground">ID:</span>
-                <code className="text-xs font-mono bg-muted px-2 py-0.5 rounded">{trace.id}</code>
-                <CopyButton text={trace.id} />
-              </div>
-
               {/* Stats row */}
-              <div className="flex items-start gap-6 text-sm">
-                <div>
-                  <div className="text-muted-foreground text-xs mb-1">Status</div>
-                  <Badge variant={traceStats?.hasErrors ? "destructive" : traceStats?.hasWarnings ? "secondary" : "default"}>
-                    {traceStats?.hasErrors ? "Error" : traceStats?.hasWarnings ? "Warning" : "Success"}
+              <div className="flex items-start gap-6 text-sm flex-wrap">
+                <StatItem label="Status">
+                  <Badge
+                    variant={
+                      stats?.hasErrors
+                        ? "destructive"
+                        : stats?.hasWarnings
+                          ? "secondary"
+                          : "default"
+                    }
+                    className={cn(
+                      !stats?.hasErrors &&
+                        !stats?.hasWarnings &&
+                        "bg-green-500/10 text-green-600 hover:bg-green-500/20"
+                    )}
+                  >
+                    {stats?.hasErrors
+                      ? "Error"
+                      : stats?.hasWarnings
+                        ? "Warning"
+                        : "Success"}
                   </Badge>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs mb-1">Time</div>
-                  <div className="font-medium">{format(new Date(trace.timestamp), "h:mm a")}</div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs mb-1">Duration</div>
-                  <div className="font-medium">{formatDuration(traceStats?.duration ?? null)}</div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs mb-1">Spans</div>
-                  <div className="font-medium">{traceStats?.spanCount}</div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs mb-1">Tokens</div>
-                  <div className="font-medium">{formatTokens(traceStats?.totalTokens ?? null)}</div>
-                </div>
+                </StatItem>
+                <StatItem label="Time">
+                  <span className="font-medium">
+                    {format(new Date(trace.timestamp), "h:mm a")}
+                  </span>
+                </StatItem>
+                <StatItem label="Duration">
+                  <span className="font-medium">
+                    {formatDuration(stats?.duration ?? null)}
+                  </span>
+                </StatItem>
+                <StatItem label="Spans">
+                  <span className="font-medium">{stats?.spanCount}</span>
+                </StatItem>
+                <StatItem label="Tokens">
+                  <span className="font-medium">
+                    {formatTokens(stats?.totalTokens ?? null)}
+                  </span>
+                </StatItem>
+                {stats?.primaryModel && (
+                  <StatItem label="Model">
+                    <Badge variant="outline" className="gap-1">
+                      <Cpu className="h-3 w-3" />
+                      {stats.primaryModel}
+                    </Badge>
+                  </StatItem>
+                )}
               </div>
             </div>
 
-            {/* Timeline Section */}
-            <div className="flex-1 overflow-hidden border-t">
-              <ScrollArea className="h-full">
-                <div className="p-6">
-                  {/* Section header */}
-                  <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-base font-semibold">Timeline</h3>
-                    {traceStats?.primaryModel && (
-                      <Badge variant="outline" className="gap-1">
-                        <Cpu className="h-3 w-3" />
-                        {traceStats.primaryModel}
-                      </Badge>
-                    )}
-                  </div>
+            {/* Main content: Waterfall + Detail sidebar */}
+            <div className="flex flex-1 overflow-hidden">
+              {/* Waterfall (flex-1 or shrink when sidebar open) */}
+              <div
+                className={cn(
+                  "flex-1 overflow-hidden p-4",
+                  selectedSpanId && "hidden sm:block"
+                )}
+              >
+                <TraceWaterfall
+                  spanTree={spanTree}
+                  traceDuration={stats?.duration ?? 1000}
+                  selectedSpanId={selectedSpanId}
+                  onSpanSelect={handleSpanSelect}
+                />
+              </div>
 
-                  {/* Timeline - Git tree style */}
-                  <div className="relative pl-4">
-                    {/* Start marker */}
-                    <div className="flex items-center gap-3 mb-4">
-                      <div className="text-xs text-muted-foreground w-20 text-right font-mono">
-                        {format(new Date(trace.timestamp), "h:mm:ss")}
-                      </div>
-                      <div className="w-3 h-3 rounded-full bg-primary flex-shrink-0" />
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <span className="font-mono">&gt;</span>
-                        <span>trace started</span>
-                      </div>
-                    </div>
-
-                    {/* Spans with tree indentation */}
-                    <div className="relative ml-12">
-                      {/* Vertical line connecting all spans */}
-                      <div className="absolute left-[4.5rem] top-0 bottom-8 w-0.5 bg-border" />
-
-                      {trace.spans.map((span: SpanItem) => (
-                        <SpanTimelineItem
-                          key={span.id}
-                          span={span}
-                        />
-                      ))}
-                    </div>
-
-                    {/* End marker */}
-                    {trace.spans.length > 0 && (() => {
-                      const endTimes = trace.spans
-                        .filter((s) => s.endTime)
-                        .map((s) => new Date(s.endTime!).getTime());
-                      if (endTimes.length === 0) return null;
-                      const lastEndTime = new Date(Math.max(...endTimes));
-                      return (
-                        <div className="flex items-center gap-3 mt-4">
-                          <div className="text-xs text-muted-foreground w-20 text-right font-mono">
-                            {format(lastEndTime, "h:mm:ss")}
-                          </div>
-                          <div className="w-3 h-3 rounded-full bg-muted-foreground/40 flex-shrink-0" />
-                          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                            <span className="font-mono">&lt;</span>
-                            <span>trace completed</span>
-                          </div>
-                        </div>
-                      );
-                    })()}
-                  </div>
-                </div>
-              </ScrollArea>
+              {/* Span detail sidebar (conditional) */}
+              {selectedSpanId && (
+                <SpanDetailSidebar
+                  workspaceSlug={workspaceSlug}
+                  projectId={projectId}
+                  traceId={traceId!}
+                  spanId={selectedSpanId}
+                  onClose={handleCloseSidebar}
+                />
+              )}
             </div>
-          </>
+          </div>
         )}
       </SheetContent>
     </Sheet>
   );
 }
 
-interface SpanTimelineItemProps {
-  span: SpanItem;
-}
-
-function SpanTimelineItem({ span }: SpanTimelineItemProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [copiedField, setCopiedField] = useState<string | null>(null);
-
-  const status = getSpanStatus(span);
-  const isError = span.level === "ERROR";
-  const isWarning = span.level === "WARNING";
-  const isInProgress = !span.endTime;
-
-  const handleCopy = useCallback((text: string, field: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedField(field);
-    setTimeout(() => setCopiedField(null), 2000);
-  }, []);
-
-  const handleToggle = useCallback(() => {
-    setIsOpen((prev) => !prev);
-  }, []);
-
-  const renderCopyButton = useCallback(
-    (text: string, field: string) => (
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-6 w-6"
-        onClick={(e) => {
-          e.stopPropagation();
-          handleCopy(text, field);
-        }}
-      >
-        {copiedField === field ? (
-          <Check className="h-3 w-3" />
-        ) : (
-          <Copy className="h-3 w-3" />
-        )}
-      </Button>
-    ),
-    [copiedField, handleCopy]
-  );
-
+function StatItem({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="flex items-start gap-3 relative mb-2">
-      {/* Time column */}
-      <div className="text-xs text-muted-foreground w-16 text-right font-mono pt-2.5 flex-shrink-0">
-        {format(new Date(span.startTime), "h:mm:ss")}
-      </div>
-
-      {/* Git branch connector */}
-      <div className="flex items-start pt-2.5 flex-shrink-0">
-        {/* Dot on the main line */}
-        <div
-          className={cn(
-            "w-2.5 h-2.5 rounded-full flex-shrink-0 z-10 relative",
-            isError && "bg-destructive",
-            isWarning && "bg-yellow-500",
-            !isError && !isWarning && isInProgress && "bg-primary/50 ring-2 ring-primary",
-            !isError && !isWarning && !isInProgress && "bg-primary"
-          )}
-        />
-        {/* Horizontal branch line */}
-        <div className="w-8 h-0.5 bg-border mt-[4px]" />
-      </div>
-
-      {/* Content with tree indentation */}
-      <div className="flex-1 min-w-0 pl-2">
-        {/* Header row */}
-        <button
-          onClick={handleToggle}
-          className="w-full flex items-center justify-between py-2.5 px-4 hover:bg-muted/50 rounded-lg transition-colors border border-transparent hover:border-border"
-        >
-          <div className="flex items-center gap-3 min-w-0">
-            {/* Branch indicator */}
-            <span className="text-muted-foreground/60 font-mono text-sm">├─</span>
-            <span className="font-medium truncate">{span.name}</span>
-            {span.model && (
-              <Badge variant="outline" className="text-xs font-normal flex-shrink-0">
-                {span.model}
-              </Badge>
-            )}
-          </div>
-          <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-            <Badge
-              variant={status.variant}
-              className={cn(
-                "text-xs",
-                status.variant === "default" && "bg-green-500/10 text-green-600 hover:bg-green-500/20"
-              )}
-            >
-              {status.label}
-            </Badge>
-            {isOpen ? (
-              <ChevronUp className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <ChevronDown className="h-4 w-4 text-muted-foreground" />
-            )}
-          </div>
-        </button>
-
-        {/* Expanded content */}
-        {isOpen && (
-          <div className="mt-2 ml-8 mr-2 space-y-4 border rounded-lg p-4 bg-muted/20 overflow-hidden">
-            {/* Span ID */}
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">Span ID:</span>
-              <code className="text-xs font-mono bg-background px-2 py-0.5 rounded border">{span.id}</code>
-              <CopyButton text={span.id} />
-            </div>
-
-            {/* Info grid */}
-            <div className="grid grid-cols-2 gap-4 text-sm">
-              <div>
-                <div className="text-muted-foreground text-xs mb-1">Start Time</div>
-                <div className="font-mono text-xs">
-                  {format(new Date(span.startTime), "h:mm:ss.SSS a")}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground text-xs mb-1">Duration</div>
-                <div className="font-mono text-xs">
-                  {formatSpanDuration(span.startTime, span.endTime)}
-                </div>
-              </div>
-            </div>
-
-            {/* Token usage */}
-            {span.totalTokens && (
-              <div>
-                <div className="text-muted-foreground text-xs mb-2">Token Usage</div>
-                <div className="grid grid-cols-3 gap-4 text-sm">
-                  <div>
-                    <div className="text-muted-foreground text-xs">Prompt</div>
-                    <div className="font-mono">{formatTokens(span.promptTokens)}</div>
-                  </div>
-                  <div>
-                    <div className="text-muted-foreground text-xs">Completion</div>
-                    <div className="font-mono">{formatTokens(span.completionTokens)}</div>
-                  </div>
-                  <div>
-                    <div className="text-muted-foreground text-xs">Total</div>
-                    <div className="font-mono">{formatTokens(span.totalTokens)}</div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Input */}
-            {span.input !== null && span.input !== undefined && (
-              <div className="min-w-0">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="text-muted-foreground text-xs">Input</div>
-                  {renderCopyButton(JSON.stringify(span.input, null, 2), `input-${span.id}`)}
-                </div>
-                <pre className="p-3 bg-background rounded-lg text-xs overflow-auto max-h-48 border whitespace-pre-wrap break-all">
-                  {JSON.stringify(span.input, null, 2)}
-                </pre>
-              </div>
-            )}
-
-            {/* Output */}
-            {span.output !== null && span.output !== undefined && (
-              <div className="min-w-0">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="text-muted-foreground text-xs">Output</div>
-                  {renderCopyButton(JSON.stringify(span.output, null, 2), `output-${span.id}`)}
-                </div>
-                <pre className="p-3 bg-background rounded-lg text-xs overflow-auto max-h-48 border whitespace-pre-wrap break-all">
-                  {JSON.stringify(span.output, null, 2)}
-                </pre>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+    <div>
+      <div className="text-muted-foreground text-xs mb-1">{label}</div>
+      {children}
     </div>
   );
 }
@@ -464,19 +223,35 @@ function TraceDetailSkeleton() {
         </div>
       </div>
 
-      {/* Timeline skeleton */}
-      <div className="space-y-4 pt-4 border-t">
-        <Skeleton className="h-5 w-20" />
-        {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="flex gap-4">
-            <Skeleton className="h-3 w-3 rounded-full" />
-            <div className="flex-1 space-y-2">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-12 w-full" />
-            </div>
-          </div>
+      {/* Waterfall skeleton */}
+      <div className="space-y-2 pt-4 border-t">
+        <Skeleton className="h-8 w-full" />
+        {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+          <Skeleton key={i} className="h-11 w-full" />
         ))}
       </div>
+    </div>
+  );
+}
+
+function TraceDetailError({
+  error,
+  onRetry,
+}: {
+  error: Error;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+      <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+      <h3 className="text-lg font-semibold mb-2">Failed to load trace</h3>
+      <p className="text-sm text-muted-foreground mb-4 max-w-md">
+        {error.message || "An unexpected error occurred while loading the trace details."}
+      </p>
+      <Button variant="outline" onClick={onRetry} className="gap-2">
+        <RefreshCw className="h-4 w-4" />
+        Try again
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/components/traces/trace-timeline-header.tsx
+++ b/apps/web/src/components/traces/trace-timeline-header.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMemo } from "react";
+import { getTimeScaleConfig, WATERFALL } from "./waterfall-constants";
+
+interface TimelineHeaderProps {
+  durationMs: number;
+}
+
+interface TimeMarker {
+  position: number;
+  label: string;
+}
+
+/**
+ * Timeline header with auto-scaled time markers.
+ * Positioned above the waterfall rows.
+ */
+export function TimelineHeader({ durationMs }: TimelineHeaderProps) {
+  const markers = useMemo((): TimeMarker[] => {
+    const config = getTimeScaleConfig(durationMs);
+    const result: TimeMarker[] = [];
+
+    for (let ms = 0; ms <= durationMs; ms += config.interval) {
+      result.push({
+        position: (ms / durationMs) * 100,
+        label: config.format(ms),
+      });
+    }
+
+    return result;
+  }, [durationMs]);
+
+  return (
+    <div
+      className="relative h-8 border-b bg-muted/30 flex-shrink-0"
+      style={{ marginLeft: WATERFALL.NAME_COLUMN_WIDTH }}
+    >
+      {markers.map((marker, index) => (
+        <div
+          key={index}
+          className="absolute top-0 h-full border-l border-muted-foreground/20"
+          style={{ left: `${marker.position}%` }}
+        >
+          <span className="absolute top-1 left-1 text-xs text-muted-foreground font-mono">
+            {marker.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/traces/trace-waterfall-row.tsx
+++ b/apps/web/src/components/traces/trace-waterfall-row.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, { useCallback } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FlatWaterfallSpan, SpanLevel } from "@/lib/traces/types";
+import {
+  SPAN_TYPE_CONFIG,
+  SPAN_LEVEL_COLORS,
+  SPAN_LEVEL_BORDER,
+} from "./span-type-config";
+import { WATERFALL } from "./waterfall-constants";
+
+interface WaterfallRowProps {
+  span: FlatWaterfallSpan;
+  isSelected: boolean;
+  onSelect: () => void;
+  onToggleCollapse: () => void;
+}
+
+const formatDuration = (ms: number | null): string => {
+  if (ms === null) return "";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+};
+
+/**
+ * Single row in the waterfall visualization.
+ * Memoized with custom equality check for performance.
+ */
+export const WaterfallRow = React.memo(
+  function WaterfallRow({
+    span,
+    isSelected,
+    onSelect,
+    onToggleCollapse,
+  }: WaterfallRowProps) {
+    const typeConfig = SPAN_TYPE_CONFIG[span.type];
+    const TypeIcon = typeConfig.icon;
+    const hasChildren = span.children.length > 0;
+    const level = span.level as SpanLevel;
+
+    const handleCollapseClick = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onToggleCollapse();
+      },
+      [onToggleCollapse]
+    );
+
+    return (
+      <div
+        id={`span-${span.id}`}
+        className={cn(
+          "flex items-center cursor-pointer hover:bg-muted/50 border-b transition-colors",
+          isSelected && "bg-muted",
+          level === "ERROR" && "bg-red-50 dark:bg-red-950/20"
+        )}
+        style={{ height: WATERFALL.ROW_HEIGHT }}
+        onClick={onSelect}
+      >
+        {/* Name column */}
+        <div
+          className="flex items-center gap-2 shrink-0 px-2 overflow-hidden"
+          style={{
+            width: WATERFALL.NAME_COLUMN_WIDTH,
+            paddingLeft: Math.min(span.depth, WATERFALL.MAX_DEPTH) * WATERFALL.INDENT_PER_LEVEL + 8,
+          }}
+        >
+          {/* Collapse toggle */}
+          {hasChildren ? (
+            <button
+              onClick={handleCollapseClick}
+              className="p-0.5 hover:bg-muted rounded flex-shrink-0"
+              aria-label={span.isCollapsed ? "Expand" : "Collapse"}
+            >
+              {span.isCollapsed ? (
+                <ChevronRight className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </button>
+          ) : (
+            <span className="w-5 flex-shrink-0" />
+          )}
+
+          {/* Type icon */}
+          <TypeIcon className={cn("h-4 w-4 flex-shrink-0", typeConfig.color)} />
+
+          {/* Span name */}
+          <span className="truncate text-sm font-medium" title={span.name}>
+            {span.name}
+          </span>
+
+          {/* Collapsed child count */}
+          {span.isCollapsed && span.hiddenChildCount > 0 && (
+            <span className="text-xs text-muted-foreground flex-shrink-0">
+              (+{span.hiddenChildCount})
+            </span>
+          )}
+        </div>
+
+        {/* Timeline bar column */}
+        <div className="flex-1 relative h-full px-4">
+          <div
+            className={cn(
+              "absolute top-1/2 -translate-y-1/2 rounded border-l-4",
+              SPAN_LEVEL_COLORS[level],
+              SPAN_LEVEL_BORDER[level]
+            )}
+            style={{
+              left: `${span.percentStart}%`,
+              width: `${Math.max(span.percentWidth, 0.5)}%`,
+              height: WATERFALL.BAR_HEIGHT,
+              minWidth: WATERFALL.MIN_BAR_WIDTH,
+            }}
+          >
+            {/* Duration label inside bar */}
+            {span.duration && span.percentWidth > 5 && (
+              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-white font-mono">
+                {formatDuration(span.duration)}
+              </span>
+            )}
+          </div>
+
+          {/* Duration label outside bar (for narrow bars) */}
+          {span.duration && span.percentWidth <= 5 && (
+            <span
+              className="absolute top-1/2 -translate-y-1/2 text-xs text-muted-foreground font-mono ml-1"
+              style={{ left: `${span.percentStart + span.percentWidth}%` }}
+            >
+              {formatDuration(span.duration)}
+            </span>
+          )}
+        </div>
+
+        {/* Token badge (LLM only) */}
+        {span.totalTokens && (
+          <div className="shrink-0 px-2 text-xs text-muted-foreground font-mono">
+            {span.totalTokens.toLocaleString()} tok
+          </div>
+        )}
+      </div>
+    );
+  },
+  // Custom equality check for performance
+  (prevProps, nextProps) => {
+    return (
+      prevProps.span.id === nextProps.span.id &&
+      prevProps.isSelected === nextProps.isSelected &&
+      prevProps.span.isCollapsed === nextProps.span.isCollapsed &&
+      prevProps.span.isVisible === nextProps.span.isVisible
+    );
+  }
+);

--- a/apps/web/src/components/traces/trace-waterfall.tsx
+++ b/apps/web/src/components/traces/trace-waterfall.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useMemo, useCallback, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { WaterfallRow } from "./trace-waterfall-row";
+import { TimelineHeader } from "./trace-timeline-header";
+import { flattenSpanTree } from "@/lib/traces/span-tree";
+import { WATERFALL } from "./waterfall-constants";
+import type { WaterfallSpan } from "@/lib/traces/types";
+
+interface TraceWaterfallProps {
+  spanTree: WaterfallSpan[];
+  traceDuration: number;
+  selectedSpanId: string | null;
+  onSpanSelect: (spanId: string) => void;
+}
+
+/**
+ * Virtualized waterfall visualization of trace spans.
+ * Supports 500+ spans with smooth scrolling.
+ */
+export function TraceWaterfall({
+  spanTree,
+  traceDuration,
+  selectedSpanId,
+  onSpanSelect,
+}: TraceWaterfallProps) {
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  // Flatten tree respecting collapsed state
+  const flatSpans = useMemo(() => {
+    return flattenSpanTree(spanTree, collapsedIds);
+  }, [spanTree, collapsedIds]);
+
+  // Virtual list for performance with large traces
+  const virtualizer = useVirtualizer({
+    count: flatSpans.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => WATERFALL.ROW_HEIGHT,
+    overscan: 10, // Render 10 extra items for smooth scrolling
+  });
+
+  const handleToggleCollapse = useCallback((spanId: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(spanId)) {
+        next.delete(spanId);
+      } else {
+        next.add(spanId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSpanSelect = useCallback(
+    (spanId: string) => {
+      onSpanSelect(spanId);
+    },
+    [onSpanSelect]
+  );
+
+  if (flatSpans.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        No spans to display
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col border rounded-lg overflow-hidden h-full">
+      {/* Timeline header */}
+      <TimelineHeader durationMs={traceDuration} />
+
+      {/* Virtualized span list */}
+      <div ref={parentRef} className="flex-1 overflow-auto">
+        <div
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            width: "100%",
+            position: "relative",
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const span = flatSpans[virtualRow.index];
+            if (!span) return null;
+            return (
+              <div
+                key={span.id}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: `${virtualRow.size}px`,
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <WaterfallRow
+                  span={span}
+                  isSelected={span.id === selectedSpanId}
+                  onSelect={() => handleSpanSelect(span.id)}
+                  onToggleCollapse={() => handleToggleCollapse(span.id)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/traces/waterfall-constants.ts
+++ b/apps/web/src/components/traces/waterfall-constants.ts
@@ -1,0 +1,39 @@
+/**
+ * Layout constants for waterfall visualization.
+ */
+export const WATERFALL = {
+  /** Height of each span row in pixels */
+  ROW_HEIGHT: 44,
+  /** Indentation per hierarchy level in pixels */
+  INDENT_PER_LEVEL: 24,
+  /** Height of the timeline bar in pixels */
+  BAR_HEIGHT: 28,
+  /** Minimum width of timeline bar in pixels (for very short spans) */
+  MIN_BAR_WIDTH: 4,
+  /** Width of the name column in pixels */
+  NAME_COLUMN_WIDTH: 300,
+  /** Padding on timeline edges */
+  TIMELINE_PADDING: 16,
+  /** Maximum depth to render (prevent deep nesting issues) */
+  MAX_DEPTH: 20,
+} as const;
+
+/**
+ * Time scale intervals for timeline header.
+ * Automatically selected based on trace duration.
+ */
+export const TIME_SCALE_INTERVALS = [
+  { threshold: 100, interval: 10, format: (ms: number) => `${ms}ms` },
+  { threshold: 1000, interval: 100, format: (ms: number) => `${ms}ms` },
+  { threshold: 5000, interval: 500, format: (ms: number) => `${ms}ms` },
+  { threshold: 10000, interval: 1000, format: (ms: number) => `${ms / 1000}s` },
+  { threshold: 60000, interval: 5000, format: (ms: number) => `${ms / 1000}s` },
+  { threshold: Infinity, interval: 10000, format: (ms: number) => `${ms / 1000}s` },
+] as const;
+
+/**
+ * Gets the appropriate time scale config for a given duration.
+ */
+export function getTimeScaleConfig(durationMs: number) {
+  return TIME_SCALE_INTERVALS.find((i) => durationMs <= i.threshold)!;
+}

--- a/apps/web/src/hooks/traces/use-span-detail.ts
+++ b/apps/web/src/hooks/traces/use-span-detail.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+import type { SpanDetail } from "@cognobserve/api/client";
+
+interface UseSpanDetailOptions {
+  workspaceSlug: string;
+  projectId: string;
+  traceId: string;
+  spanId: string | null;
+}
+
+interface UseSpanDetailReturn {
+  span: SpanDetail | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Hook for lazy loading full span details (input/output/metadata).
+ * Only fetches when spanId is provided (on user click).
+ * Uses Infinity staleTime since span data is immutable.
+ */
+export function useSpanDetail({
+  workspaceSlug,
+  projectId,
+  traceId,
+  spanId,
+}: UseSpanDetailOptions): UseSpanDetailReturn {
+  const { data, isLoading, error } = trpc.traces.getSpanDetail.useQuery(
+    {
+      workspaceSlug,
+      projectId,
+      traceId,
+      spanId: spanId!,
+    },
+    {
+      enabled: !!spanId && !!workspaceSlug && !!projectId && !!traceId,
+      staleTime: Infinity, // Span data is immutable
+    }
+  );
+
+  return {
+    span: data ?? null,
+    isLoading: !!spanId && isLoading,
+    error: error as Error | null,
+  };
+}

--- a/apps/web/src/hooks/traces/use-trace-detail.ts
+++ b/apps/web/src/hooks/traces/use-trace-detail.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useMemo } from "react";
+import { trpc } from "@/lib/trpc/client";
+import { buildSpanTree, calculateTraceDuration } from "@/lib/traces";
+import type { WaterfallSpan } from "@/lib/traces";
+import type { TraceDetail } from "@cognobserve/api/client";
+
+const STALE_TIME = 5 * 60 * 1000; // 5 minutes
+
+interface UseTraceDetailOptions {
+  workspaceSlug: string;
+  projectId: string;
+  traceId: string | null;
+}
+
+interface TraceStats {
+  totalTokens: number;
+  hasErrors: boolean;
+  hasWarnings: boolean;
+  duration: number | null;
+  primaryModel: string | null;
+  spanCount: number;
+}
+
+interface UseTraceDetailReturn {
+  trace: TraceDetail | null;
+  spanTree: WaterfallSpan[];
+  stats: TraceStats | null;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+/**
+ * Hook for fetching trace detail with computed span tree.
+ * Optimized with staleTime since trace data is rarely updated.
+ */
+export function useTraceDetail({
+  workspaceSlug,
+  projectId,
+  traceId,
+}: UseTraceDetailOptions): UseTraceDetailReturn {
+  const { data, isLoading, error, refetch } = trpc.traces.get.useQuery(
+    { workspaceSlug, projectId, traceId: traceId! },
+    {
+      enabled: !!traceId && !!workspaceSlug && !!projectId,
+      staleTime: STALE_TIME,
+    }
+  );
+
+  // Compute trace statistics
+  const stats = useMemo((): TraceStats | null => {
+    if (!data) return null;
+
+    const spans = data.spans;
+    const totalTokens = spans.reduce((sum, s) => sum + (s.totalTokens ?? 0), 0);
+    const hasErrors = spans.some((s) => s.level === "ERROR");
+    const hasWarnings = spans.some((s) => s.level === "WARNING");
+    const duration = calculateTraceDuration(spans);
+
+    // Find primary model (most common)
+    const modelCounts = spans
+      .filter((s) => s.model)
+      .reduce(
+        (acc, s) => {
+          acc[s.model!] = (acc[s.model!] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>
+      );
+
+    const primaryModel =
+      Object.entries(modelCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+
+    return {
+      totalTokens,
+      hasErrors,
+      hasWarnings,
+      duration,
+      primaryModel,
+      spanCount: spans.length,
+    };
+  }, [data]);
+
+  // Build span tree for waterfall
+  const spanTree = useMemo((): WaterfallSpan[] => {
+    if (!data || !stats?.duration) return [];
+    return buildSpanTree(data.spans, stats.duration);
+  }, [data, stats?.duration]);
+
+  return {
+    trace: data ?? null,
+    spanTree,
+    stats,
+    isLoading,
+    error: error as Error | null,
+    refetch,
+  };
+}

--- a/apps/web/src/lib/traces/index.ts
+++ b/apps/web/src/lib/traces/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./span-tree";
+export * from "./infer-span-type";

--- a/apps/web/src/lib/traces/infer-span-type.ts
+++ b/apps/web/src/lib/traces/infer-span-type.ts
@@ -1,0 +1,56 @@
+import type { SpanItem } from "@cognobserve/api/client";
+import type { SpanType } from "./types";
+
+/**
+ * Infers the span type from available span data.
+ * Since the database doesn't have a type column, we infer it from:
+ * - model field (LLM spans)
+ * - name patterns (function, HTTP, DB)
+ * - level (LOG for DEBUG without model)
+ */
+export function inferSpanType(span: Pick<SpanItem, "model" | "name" | "level">): SpanType {
+  // LLM span if model is present
+  if (span.model) {
+    return "LLM";
+  }
+
+  const nameLower = span.name.toLowerCase();
+
+  // HTTP patterns
+  if (
+    nameLower.includes("http") ||
+    nameLower.includes("fetch") ||
+    nameLower.includes("request") ||
+    nameLower.includes("api call")
+  ) {
+    return "HTTP";
+  }
+
+  // Database patterns
+  if (
+    nameLower.includes("db") ||
+    nameLower.includes("database") ||
+    nameLower.includes("query") ||
+    nameLower.includes("sql") ||
+    nameLower.includes("prisma")
+  ) {
+    return "DB";
+  }
+
+  // Function patterns
+  if (
+    nameLower.includes("function") ||
+    nameLower.includes("tool") ||
+    nameLower.includes("invoke")
+  ) {
+    return "FUNCTION";
+  }
+
+  // Log patterns (DEBUG level without model)
+  if (span.level === "DEBUG") {
+    return "LOG";
+  }
+
+  // Default to CUSTOM
+  return "CUSTOM";
+}

--- a/apps/web/src/lib/traces/span-tree.ts
+++ b/apps/web/src/lib/traces/span-tree.ts
@@ -1,0 +1,156 @@
+import type { SpanItem } from "@cognobserve/api/client";
+import type { WaterfallSpan, FlatWaterfallSpan, SpanType } from "./types";
+import { inferSpanType } from "./infer-span-type";
+
+const MIN_PERCENT_WIDTH = 0.5;
+
+/**
+ * Builds a hierarchical tree from flat span list.
+ * Optimized for 500+ spans with single-pass Map construction.
+ *
+ * @param spans - Flat list of spans from API
+ * @param traceDuration - Total trace duration in ms
+ * @returns Array of root WaterfallSpan nodes with children
+ */
+export function buildSpanTree(
+  spans: SpanItem[],
+  traceDuration: number
+): WaterfallSpan[] {
+  if (spans.length === 0) return [];
+
+  // Ensure duration is at least 1ms to avoid division by zero
+  const safeDuration = Math.max(traceDuration, 1);
+  const invDuration = 100 / safeDuration;
+
+  // First pass: create WaterfallSpan nodes
+  const spanMap = new Map<string, WaterfallSpan>();
+
+  for (const span of spans) {
+    const percentStart = span.offsetFromTraceStart * invDuration;
+    const percentWidth = span.duration
+      ? Math.max(span.duration * invDuration, MIN_PERCENT_WIDTH)
+      : MIN_PERCENT_WIDTH;
+
+    const type: SpanType = inferSpanType(span);
+
+    spanMap.set(span.id, {
+      ...span,
+      depth: 0,
+      percentStart,
+      percentWidth,
+      children: [],
+      isCollapsed: false,
+      isVisible: true,
+      type,
+    });
+  }
+
+  // Second pass: build parent-child relationships
+  const roots: WaterfallSpan[] = [];
+
+  for (const span of spans) {
+    const node = spanMap.get(span.id)!;
+
+    if (span.parentSpanId && spanMap.has(span.parentSpanId)) {
+      const parent = spanMap.get(span.parentSpanId)!;
+      node.depth = parent.depth + 1;
+      parent.children.push(node);
+    } else {
+      // No parent or parent not in this trace = root node
+      roots.push(node);
+    }
+  }
+
+  // Sort children by start time (in-place)
+  const sortChildren = (node: WaterfallSpan): void => {
+    if (node.children.length > 1) {
+      node.children.sort((a, b) => a.offsetFromTraceStart - b.offsetFromTraceStart);
+    }
+    for (const child of node.children) {
+      sortChildren(child);
+    }
+  };
+
+  for (const root of roots) {
+    sortChildren(root);
+  }
+
+  // Sort roots by start time
+  roots.sort((a, b) => a.offsetFromTraceStart - b.offsetFromTraceStart);
+
+  return roots;
+}
+
+/**
+ * Counts total descendants of a node (for showing hidden count).
+ */
+function countDescendants(node: WaterfallSpan): number {
+  let count = 0;
+  for (const child of node.children) {
+    count += 1 + countDescendants(child);
+  }
+  return count;
+}
+
+/**
+ * Flattens the span tree to a list for rendering.
+ * Respects collapsed state - children of collapsed nodes are excluded.
+ *
+ * @param roots - Root nodes from buildSpanTree
+ * @param collapsedIds - Set of span IDs that are collapsed
+ * @returns Flat array of visible spans in DFS order
+ */
+export function flattenSpanTree(
+  roots: WaterfallSpan[],
+  collapsedIds: Set<string>
+): FlatWaterfallSpan[] {
+  const result: FlatWaterfallSpan[] = [];
+
+  const traverse = (node: WaterfallSpan, parentCollapsed: boolean): void => {
+    const isCollapsed = collapsedIds.has(node.id);
+    const isVisible = !parentCollapsed;
+
+    if (isVisible) {
+      const hiddenChildCount = isCollapsed ? countDescendants(node) : 0;
+
+      result.push({
+        ...node,
+        isCollapsed,
+        isVisible,
+        hiddenChildCount,
+      });
+    }
+
+    // Only traverse children if this node is visible and not collapsed
+    if (isVisible && !isCollapsed) {
+      for (const child of node.children) {
+        traverse(child, false);
+      }
+    }
+  };
+
+  for (const root of roots) {
+    traverse(root, false);
+  }
+
+  return result;
+}
+
+/**
+ * Calculates the total duration of a trace from spans.
+ *
+ * @param spans - Array of spans
+ * @returns Duration in milliseconds, or null if no spans have end times
+ */
+export function calculateTraceDuration(spans: SpanItem[]): number | null {
+  if (spans.length === 0) return null;
+
+  const startTimes = spans.map((s) => new Date(s.startTime).getTime());
+  const endTimes = spans
+    .filter((s) => s.endTime)
+    .map((s) => new Date(s.endTime!).getTime());
+
+  if (endTimes.length === 0) return null;
+
+  return Math.max(...endTimes) - Math.min(...startTimes);
+}

--- a/apps/web/src/lib/traces/types.ts
+++ b/apps/web/src/lib/traces/types.ts
@@ -1,0 +1,42 @@
+import type { SpanItem } from "@cognobserve/api/client";
+
+/**
+ * Span types for visual differentiation in waterfall view.
+ * Inferred from span data since DB doesn't have a type column.
+ */
+export type SpanType = "LLM" | "LOG" | "FUNCTION" | "HTTP" | "DB" | "CUSTOM";
+
+/**
+ * Span severity levels from the database.
+ */
+export type SpanLevel = "DEBUG" | "DEFAULT" | "WARNING" | "ERROR";
+
+/**
+ * Extended span with computed waterfall properties.
+ * Used for rendering the hierarchical waterfall visualization.
+ */
+export interface WaterfallSpan extends SpanItem {
+  /** Hierarchy depth (0 = root span) */
+  depth: number;
+  /** Start position as percentage of trace duration (0-100) */
+  percentStart: number;
+  /** Width as percentage of trace duration (0-100, min 0.5 for visibility) */
+  percentWidth: number;
+  /** Child spans in the hierarchy */
+  children: WaterfallSpan[];
+  /** Whether this span's children are collapsed */
+  isCollapsed: boolean;
+  /** Whether this span is visible (false if parent is collapsed) */
+  isVisible: boolean;
+  /** Inferred span type for icon/color */
+  type: SpanType;
+}
+
+/**
+ * Flattened span for rendering in virtualized list.
+ * Includes visibility state based on collapsed parents.
+ */
+export interface FlatWaterfallSpan extends WaterfallSpan {
+  /** Number of hidden children when collapsed */
+  hiddenChildCount: number;
+}

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -46,4 +46,4 @@ export type {
   WorkspaceMemberItem,
 } from "./routers/workspaces";
 export type { ProjectListItem, ProjectDetail } from "./routers/projects";
-export type { TraceListItem, TraceDetail, SpanItem } from "./routers/traces";
+export type { TraceListItem, TraceDetail, SpanItem, SpanDetail } from "./routers/traces";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.90.11(react@19.2.0)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.12
+        version: 3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@trpc/client':
         specifier: ^11.0.0
         version: 11.7.2(@trpc/server@11.7.2(typescript@5.9.3))(typescript@5.9.3)
@@ -1725,6 +1728,15 @@ packages:
     resolution: {integrity: sha512-3uyzz01D1fkTLXuxF3JfoJoHQMU2fxsfJwE+6N5hHy0dVNoZOvwKP8Z2k7k1KDeD54N20apcJnG75TBAStIrBA==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5183,6 +5195,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.11
       react: 19.2.0
+
+  '@tanstack/react-virtual@3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Significant refactoring of trace visualization UI with improved performance for large traces (500+ spans).

Major changes:
- Refactored `trace-detail-panel.tsx` to extract waterfall and span detail into separate components
- Added virtualized waterfall rendering using `@tanstack/react-virtual` for performance with large traces
- Implemented hierarchical span tree visualization with collapse/expand functionality
- Created custom hooks (`use-trace-detail`, `use-span-detail`) following project patterns
- Added lazy-loading for span details (input/output/metadata) via new `getSpanDetail` API endpoint
- Implemented span type inference system (LLM, HTTP, DB, FUNCTION, LOG, CUSTOM) with visual configuration
- Added timeline header with auto-scaling time markers
- Memoized waterfall row component with custom equality check for render optimization

Minor issues:
- Inline arrow functions in JSX violate code style (trace-waterfall.tsx:103-104)

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor style fix recommended
- Well-architected refactor with proper separation of concerns, custom hooks, and performance optimizations. Only issue is a minor code style violation (inline arrow functions in JSX). Logic is sound, no race conditions or security issues detected.
- apps/web/src/components/traces/trace-waterfall.tsx needs inline functions extracted per style guide

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/components/traces/trace-detail-panel.tsx | 5/5 | Refactored to use custom hooks and extracted waterfall/sidebar to separate components |
| apps/web/src/components/traces/trace-waterfall.tsx | 4/5 | New virtualized waterfall component with collapse/expand - has inline arrow functions in JSX |
| apps/web/src/hooks/traces/use-trace-detail.ts | 5/5 | Hook for fetching trace with computed span tree and statistics |
| apps/web/src/lib/traces/span-tree.ts | 5/5 | Tree building and flattening logic optimized for 500+ spans |
| packages/api/src/routers/traces.ts | 5/5 | Added `getSpanDetail` endpoint for lazy-loading full span data |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TraceDetailPanel
    participant useTraceDetail
    participant TracesAPI
    participant TraceWaterfall
    participant SpanDetailSidebar
    participant useSpanDetail

    User->>TraceDetailPanel: Opens trace detail
    TraceDetailPanel->>useTraceDetail: Fetch trace data
    useTraceDetail->>TracesAPI: traces.get(traceId)
    TracesAPI-->>useTraceDetail: TraceDetail with spans
    useTraceDetail->>useTraceDetail: buildSpanTree()
    useTraceDetail->>useTraceDetail: Calculate stats
    useTraceDetail-->>TraceDetailPanel: trace, spanTree, stats
    TraceDetailPanel->>TraceWaterfall: Render waterfall
    TraceWaterfall->>TraceWaterfall: flattenSpanTree()
    TraceWaterfall->>TraceWaterfall: Setup virtualizer
    TraceWaterfall-->>TraceDetailPanel: Display virtualized rows
    
    User->>TraceWaterfall: Clicks span row
    TraceWaterfall->>TraceDetailPanel: onSpanSelect(spanId)
    TraceDetailPanel->>SpanDetailSidebar: Show sidebar
    SpanDetailSidebar->>useSpanDetail: Fetch span details
    useSpanDetail->>TracesAPI: traces.getSpanDetail(spanId)
    TracesAPI-->>useSpanDetail: SpanDetail with input/output
    useSpanDetail-->>SpanDetailSidebar: Full span data
    SpanDetailSidebar-->>User: Display detailed span info
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=92847595-c8d7-48c0-8b3b-76fbf797662d))

<!-- /greptile_comment -->