### PR TITLE
feat: add total users count to project header

### DIFF
--- a/apps/web/src/app/workspace/[workspaceSlug]/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/workspace/[workspaceSlug]/projects/[projectId]/page.tsx
@@ -13,6 +13,8 @@ import { TracesTable } from "@/components/traces/traces-table";
 import { SessionsTable } from "@/components/sessions/sessions-table";
 import { TrackedUsersTable } from "@/components/tracked-users/tracked-users-table";
 import { AlertsPanel } from "@/components/alerts/alerts-panel";
+import { useProjectUserCount } from "@/hooks/project-user-count/use-project-user-count";
+import { Badge } from "@/components/ui/badge";
 
 type ProjectTab = "traces" | "sessions" | "users";
 
@@ -30,6 +32,11 @@ export default function ProjectDetailPage() {
       { workspaceSlug: workspaceSlug ?? "", projectId },
       { enabled: !!workspaceSlug && !!projectId }
     );
+
+  const { userCount, isLoading: isLoadingUsers } = useProjectUserCount({
+    workspaceSlug: workspaceSlug ?? "",
+    projectId,
+  });
 
   const handleTabChange = useCallback(
     (tab: string) => {
@@ -88,7 +95,17 @@ export default function ProjectDetailPage() {
             </Link>
           </Button>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">{project.name}</h1>
+            <div className="flex items-center gap-3">
+              <h1 className="text-3xl font-bold tracking-tight">{project.name}</h1>
+              {isLoadingUsers ? (
+                <Skeleton className="h-6 w-20" />
+              ) : (
+                <Badge variant="secondary" className="gap-1">
+                  <Users className="h-3 w-3" />
+                  {userCount} users
+                </Badge>
+              )}
+            </div>
             <p className="text-muted-foreground">
               Created {new Date(project.createdAt).toLocaleDateString()}
             </p>

--- a/apps/web/src/hooks/project-user-count/use-project-user-count.ts
+++ b/apps/web/src/hooks/project-user-count/use-project-user-count.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+
+interface UseProjectUserCountOptions {
+  workspaceSlug: string;
+  projectId: string;
+}
+
+export function useProjectUserCount({ workspaceSlug, projectId }: UseProjectUserCountOptions) {
+  const { data, isLoading, error } = trpc.trackedUsers.summary.useQuery(
+    { workspaceSlug, projectId },
+    { enabled: !!workspaceSlug && !!projectId }
+  );
+
+  return {
+    userCount: data?.totalUsers ?? 0,
+    isLoading,
+    error,
+  };
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added total user count badge to project header that displays the number of tracked users for each project.

- Created `useProjectUserCount` hook to encapsulate API call to `trackedUsers.summary`
- Integrated user count badge in project header with loading skeleton
- Used existing tRPC endpoint and service layer

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues
- The implementation follows all code style guidelines including hook extraction, proper error handling, and component structure. The API endpoint already exists and is properly tested.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/hooks/project-user-count/use-project-user-count.ts | 5/5 | Created custom hook to fetch project user count from API |
| apps/web/src/app/workspace/[workspaceSlug]/projects/[projectId]/page.tsx | 5/5 | Added user count badge to project header using new hook |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Page as ProjectDetailPage
    participant Hook as useProjectUserCount
    participant TRPC as tRPC Client
    participant API as trackedUsers.summary
    participant Service as TrackedUserService
    participant DB as PostgreSQL

    Page->>Hook: Call useProjectUserCount({workspaceSlug, projectId})
    Hook->>TRPC: trpc.trackedUsers.summary.useQuery({workspaceSlug, projectId})
    TRPC->>API: Query trackedUsers.summary endpoint
    API->>Service: TrackedUserService.getSummary(projectId, workspaceId)
    Service->>DB: Count total tracked users in project
    DB-->>Service: Return user count
    Service-->>API: Return {totalUsers, activeUsers, newUsers}
    API-->>TRPC: Return summary data
    TRPC-->>Hook: Return {data: {totalUsers}, isLoading, error}
    Hook-->>Page: Return {userCount, isLoading, error}
    Page->>Page: Render badge with user count
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->