### PR TITLE
feat: update navigation bar

### DIFF
--- a/apps/web/src/components/layout/nav-main.tsx
+++ b/apps/web/src/components/layout/nav-main.tsx
@@ -18,12 +18,37 @@ interface NavItem {
   icon: typeof LayoutDashboard;
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { title: "Dashboard", path: "", icon: LayoutDashboard },
-  { title: "Projects", path: "/projects", icon: FolderKanban },
-  { title: "Traces", path: "/traces", icon: Activity },
-  { title: "Prompts", path: "/prompts", icon: FileCode },
-  { title: "Settings", path: "/settings", icon: Settings },
+interface NavGroup {
+  label: string;
+  items: NavItem[];
+}
+
+const NAV_GROUPS: NavGroup[] = [
+  {
+    label: "Overview",
+    items: [
+      { title: "Dashboard", path: "", icon: LayoutDashboard },
+      { title: "Projects", path: "/projects", icon: FolderKanban },
+    ],
+  },
+  {
+    label: "Observability",
+    items: [
+      { title: "Traces", path: "/traces", icon: Activity },
+    ],
+  },
+  {
+    label: "Developer Tools",
+    items: [
+      { title: "Prompts", path: "/prompts", icon: FileCode },
+    ],
+  },
+  {
+    label: "Configuration",
+    items: [
+      { title: "Settings", path: "/settings", icon: Settings },
+    ],
+  },
 ];
 
 export function NavMain() {
@@ -46,12 +71,14 @@ export function NavMain() {
     );
   };
 
-  return (
-    <SidebarGroup>
-      <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+  const renderGroup = (group: NavGroup) => (
+    <SidebarGroup key={group.label}>
+      <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
       <SidebarGroupContent>
-        <SidebarMenu>{NAV_ITEMS.map(renderNavItem)}</SidebarMenu>
+        <SidebarMenu>{group.items.map(renderNavItem)}</SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>
   );
+
+  return <>{NAV_GROUPS.map(renderGroup)}</>;
 }

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -431,7 +431,12 @@ const SidebarGroup = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn(
+        "relative flex w-full min-w-0 flex-col p-2",
+        // Reduce vertical padding when collapsed to icon mode
+        "group-data-[collapsible=icon]:py-0.5",
+        className
+      )}
       {...props}
     />
   )
@@ -449,8 +454,9 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity,height] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Completely hide label when collapsed (no height, no margin)
+        "group-data-[collapsible=icon]:h-0 group-data-[collapsible=icon]:overflow-hidden group-data-[collapsible=icon]:opacity-0",
         className
       )}
       {...props}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR reorganizes the navigation sidebar into logical grouped sections, improving information architecture and visual hierarchy.

**Key Changes:**
- Restructured navigation from flat `NAV_ITEMS` to grouped `NAV_GROUPS` with four categories: Overview, Observability, Developer Tools, and Configuration
- Enhanced sidebar collapse behavior with better label hiding (using `h-0` + `overflow:hidden` instead of negative margin) and reduced padding in icon mode
- Follows code style guidelines with proper constant naming (`UPPER_SNAKE_CASE`), extracted render functions, and no inline functions

**Code Quality:**
- Clean separation of concerns with `renderGroup` function
- Type-safe with proper TypeScript interfaces (`NavGroup`, `NavItem`)
- Minor improvement suggested for explicit container element

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it's a UI refactoring with no business logic changes
- Score reflects well-structured code following project conventions, with only a minor style suggestion for the container element. The changes are purely presentational and won't affect functionality.
- No files require special attention - both changes are straightforward UI improvements

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/layout/nav-main.tsx | Reorganized navigation from flat list to grouped sections (Overview, Observability, Developer Tools, Configuration), follows code style rules with extracted render functions and proper constants |
| apps/web/src/components/ui/sidebar.tsx | Improved collapsed sidebar styling by reducing padding in icon mode and properly hiding group labels with height:0 + overflow:hidden instead of negative margin |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant NavMain
    participant SidebarGroup
    participant SidebarGroupLabel
    participant SidebarMenu
    participant NavLink

    User->>NavMain: Render navigation
    NavMain->>NavMain: Map over NAV_GROUPS
    
    loop For each group
        NavMain->>SidebarGroup: renderGroup
        SidebarGroup->>SidebarGroupLabel: Render label
        Note over SidebarGroupLabel: Hidden with h-0 when collapsed
        SidebarGroup->>SidebarMenu: Render menu items
        
        loop For each nav item
            SidebarMenu->>NavMain: renderNavItem
            NavMain->>NavLink: Create link
            NavLink-->>User: Display icon and text
        end
    end
    
    User->>User: Toggle sidebar collapse
    Note over SidebarGroup: Padding reduced to py-0.5
    Note over SidebarGroupLabel: Completely hidden
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->