### PR TITLE
fix(traces): support free-text search and clear filters on empty query

### DIFF
--- a/apps/web/src/components/traces/filters-v2/query-builder-input.tsx
+++ b/apps/web/src/components/traces/filters-v2/query-builder-input.tsx
@@ -35,6 +35,8 @@ interface QueryBuilderInputProps {
   onExecute: (query: string) => void;
   /** Whether a search is currently in progress */
   isLoading?: boolean;
+  /** Whether there are active filters (enables execute with empty query to clear) */
+  hasFilters?: boolean;
   placeholder?: string;
   className?: string;
 }
@@ -254,6 +256,7 @@ export function QueryBuilderInput({
   onChange,
   onExecute,
   isLoading = false,
+  hasFilters = false,
   placeholder = 'service.name="api" AND span.type="HTTP"',
   className,
 }: QueryBuilderInputProps) {
@@ -345,11 +348,12 @@ export function QueryBuilderInput({
   }, [onChange]);
 
   const handleExecute = useCallback(() => {
-    if (value.trim() && !isLoading) {
+    // Allow execute if there's text OR if there are active filters to clear
+    if ((value.trim() || hasFilters) && !isLoading) {
       setShowSuggestions(false);
       onExecute(value.trim());
     }
-  }, [value, isLoading, onExecute]);
+  }, [value, hasFilters, isLoading, onExecute]);
 
   const applySuggestion = useCallback(
     (suggestion: Suggestion) => {
@@ -511,7 +515,7 @@ export function QueryBuilderInput({
               variant="default"
               size="sm"
               onClick={handleExecute}
-              disabled={!value.trim() || isLoading}
+              disabled={(!value.trim() && !hasFilters) || isLoading}
               className="h-8 px-2.5"
             >
               {isLoading ? (

--- a/apps/web/src/components/traces/traces-table-v2.tsx
+++ b/apps/web/src/components/traces/traces-table-v2.tsx
@@ -337,9 +337,23 @@ export function TracesTableV2({
       // Parse the query into conditions
       const conditions = parseQueryToConditions(query);
 
-      // Build filter expression directly (single state update)
+      // If no structured conditions (field=value), treat as full-text search
       if (conditions.length === 0) {
-        setFilter(null);
+        const trimmed = query.trim();
+        if (trimmed) {
+          // Use full-text search for plain text queries
+          // Replace all filters with search filter (not add to existing)
+          setFilter({
+            search: {
+              query: trimmed,
+              scope: "both",
+              mode: "terms",
+            },
+          });
+        } else {
+          // Empty query - clear all filters
+          setFilter(null);
+        }
         return;
       }
 
@@ -380,6 +394,7 @@ export function TracesTableV2({
         onChange={setQueryInput}
         onExecute={handleExecute}
         isLoading={isExecuting || isFetching}
+        hasFilters={hasFilters}
         className="flex-1"
       />
 


### PR DESCRIPTION
## Summary
- Add free-text search support: typing plain text (e.g., "custom") now performs a full-text search across traces and spans
- Fix empty query execution: clearing the search input and executing now properly clears all active filters
- Add `hasFilters` prop to `QueryBuilderInput` to enable the execute button when filters exist

## Problem
Previously, when typing plain text like "custom" in the trace search box:
1. The query wasn't being applied (only `field=value` syntax was recognized)
2. Clearing the input and executing did nothing because the button was disabled
3. Search predicates were being added to existing filters instead of replacing them

## Solution
1. When no structured conditions (`field=value`) are found but text exists, treat it as a full-text search using the existing `searchText` column
2. Allow executing with empty query when there are active filters to clear them
3. Replace filters instead of accumulating them when searching

## Test plan
- [ ] Type plain text like "custom" and hit execute - should filter traces/spans containing that text
- [ ] Clear the search input and execute - should clear all filter chips
- [ ] Verify structured queries like `service.name="api"` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds free-text search capability for traces, allowing plain text queries like "custom" to search across traces and spans
- Enables clearing all active filters by executing an empty query
- Introduces `hasFilters` prop to `QueryBuilderInput` component to enable execute button when filters exist but input is empty

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| apps/web/src/components/traces/filters-v2/query-builder-input.tsx | Added `hasFilters` prop to enable executing empty queries for clearing filters |
| apps/web/src/components/traces/traces-table-v2.tsx | Implemented free-text search logic and filter replacement strategy for plain text queries |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects straightforward UI enhancement with clear logic and proper prop handling
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant QueryBuilderInput
    participant TracesTableV2
    participant TraceFiltersHook
    participant Router
    participant tRPC
    participant IngestNode

    User->>QueryBuilderInput: "Types search query"
    QueryBuilderInput->>QueryBuilderInput: "parseQueryInput()"
    QueryBuilderInput->>QueryBuilderInput: "tokenizeForHighlight()"
    User->>QueryBuilderInput: "Presses Cmd+Enter or clicks Execute"
    QueryBuilderInput->>TracesTableV2: "onExecute(query)"
    TracesTableV2->>TracesTableV2: "parseQueryToConditions()"
    TracesTableV2->>TracesTableV2: "buildFilterExpression()"
    TracesTableV2->>TraceFiltersHook: "setFilter(expression)"
    TraceFiltersHook->>Router: "updateParams(filter)"
    Router-->>TraceFiltersHook: "URL updated"
    TraceFiltersHook-->>TracesTableV2: "filter changed"
    TracesTableV2->>tRPC: "traces.listV2.useInfiniteQuery"
    tRPC->>IngestNode: "POST /api/traces/list"
    IngestNode-->>tRPC: "Returns filtered traces"
    tRPC-->>TracesTableV2: "Returns trace data"
    TracesTableV2->>TracesTableV2: "Renders trace results"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=62661dfd-5493-4dfb-b1ef-da76c03a640d))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=104053a9-4e3b-4a4a-916b-c37cc11512a9))

<!-- /greptile_comment -->