### PR TITLE
refactor: workspace switching

### DIFF
--- a/apps/web/src/app/workspace/[workspaceSlug]/layout.tsx
+++ b/apps/web/src/app/workspace/[workspaceSlug]/layout.tsx
@@ -62,6 +62,13 @@ export default async function WorkspaceLayout({
     redirect("/login");
   }
 
+  // Check if user is a system admin
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { isSystemAdmin: true },
+  });
+  const isAdmin = user?.isSystemAdmin ?? false;
+
   // Verify user has access to this workspace
   const membership = await prisma.workspaceMember.findFirst({
     where: {
@@ -80,14 +87,28 @@ export default async function WorkspaceLayout({
     },
   });
 
-  if (!membership) {
+  // System admins can access any workspace, even without membership
+  if (!membership && !isAdmin) {
     notFound();
   }
 
-  const workspace = {
-    ...membership.workspace,
-    role: membership.role,
-  };
+  let workspace;
+  if (membership) {
+    workspace = {
+      ...membership.workspace,
+      role: membership.role,
+    };
+  } else {
+    // System admin without membership — fetch workspace directly
+    const ws = await prisma.workspace.findUnique({
+      where: { slug: resolvedParams.workspaceSlug },
+      select: { id: true, name: true, slug: true, isPersonal: true },
+    });
+    if (!ws) {
+      notFound();
+    }
+    workspace = { ...ws, role: "ADMIN" as const };
+  }
 
   // Fetch active theme for this workspace
   const activeTheme = await getActiveTheme(workspace.id);

--- a/apps/web/src/app/workspace/[workspaceSlug]/settings/layout.tsx
+++ b/apps/web/src/app/workspace/[workspaceSlug]/settings/layout.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import { Settings, Users, Key, Building2, Globe, Bell, Github, Puzzle, Palette } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWorkspaceUrl } from "@/hooks/use-workspace-url";
-import { AdminWorkspaceSwitcher } from "@/components/settings/admin-workspace-switcher";
 
 interface SettingsNavItem {
   title: string;
@@ -65,11 +64,6 @@ export default function SettingsLayout({ children }: SettingsLayoutProps) {
 
   return (
     <div className="space-y-6">
-      {/* Admin Workspace Switcher - Only shows for system admins */}
-      <div className="flex justify-end">
-        <AdminWorkspaceSwitcher />
-      </div>
-
       <div className="flex gap-6">
         {/* Inner Settings Sidebar */}
         <aside className="w-56 shrink-0">

--- a/apps/web/src/app/workspace/[workspaceSlug]/settings/page.tsx
+++ b/apps/web/src/app/workspace/[workspaceSlug]/settings/page.tsx
@@ -5,6 +5,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { AdminWorkspaceSwitcher } from "@/components/settings/admin-workspace-switcher";
 
 export default function WorkspaceSettingsGeneralPage() {
   return (
@@ -23,7 +24,9 @@ export default function WorkspaceSettingsGeneralPage() {
             Update your workspace name and details.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
+          {/* Admin workspace switcher - only visible to system admins */}
+          <AdminWorkspaceSwitcher />
           <p className="text-sm text-muted-foreground">
             Workspace settings coming soon.
           </p>

--- a/apps/web/src/components/auth/user-menu.tsx
+++ b/apps/web/src/components/auth/user-menu.tsx
@@ -91,7 +91,10 @@ export function UserMenu() {
 
           <div className="border-t border-gray-100 py-1">
             <button
-              onClick={() => signOut({ callbackUrl: "/login" })}
+              onClick={async () => {
+                await signOut({ redirect: false });
+                window.location.href = "/login";
+              }}
               className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
               data-testid="logout"
             >

--- a/apps/web/src/components/layout/nav-user.tsx
+++ b/apps/web/src/components/layout/nav-user.tsx
@@ -30,8 +30,9 @@ export function NavUser() {
     session.user.email?.[0]?.toUpperCase() ||
     "U";
 
-  const handleSignOut = () => {
-    signOut({ callbackUrl: "/login" });
+  const handleSignOut = async () => {
+    await signOut({ redirect: false });
+    window.location.href = "/login";
   };
 
   return (

--- a/apps/web/src/components/logout-button.tsx
+++ b/apps/web/src/components/logout-button.tsx
@@ -10,8 +10,9 @@ interface LogoutButtonProps {
 }
 
 export function LogoutButton({ className }: LogoutButtonProps) {
-  const handleSignOut = () => {
-    signOut({ callbackUrl: "/login" });
+  const handleSignOut = async () => {
+    await signOut({ redirect: false });
+    window.location.href = "/login";
   };
 
   return (

--- a/apps/web/src/components/settings/admin-workspace-switcher.tsx
+++ b/apps/web/src/components/settings/admin-workspace-switcher.tsx
@@ -1,66 +1,61 @@
 "use client";
 
-import { useCallback } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
 import { Check, ChevronsUpDown, Building2, User, Shield } from "lucide-react";
 import type { WorkspaceListItem } from "@ducsigr/api/client";
 
 import { Button } from "@/components/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { trpc } from "@/lib/trpc/client";
-import { useSystemAdmin } from "@/hooks/use-system-admin";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { useAdminWorkspaceSwitcher } from "@/hooks/use-admin-workspace-switcher";
 
 /**
  * Admin-only workspace switcher for the settings page.
  * Only renders for users with isSystemAdmin = true.
- * Allows quick navigation between workspace settings.
+ * Uses a searchable combobox for quick workspace navigation.
  */
 export function AdminWorkspaceSwitcher() {
-  const params = useParams();
-  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const {
+    isSystemAdmin,
+    isLoading,
+    currentSlug,
+    currentWorkspace,
+    workspaces,
+    selectWorkspace,
+  } = useAdminWorkspaceSwitcher();
 
-  // Validate workspaceSlug - can be string | string[] | undefined
-  const rawSlug = params.workspaceSlug;
-  const currentSlug = typeof rawSlug === "string" ? rawSlug : undefined;
-
-  // Check if user is system admin
-  const { isSystemAdmin, isLoading: isAdminLoading } = useSystemAdmin();
-
-  // Only fetch workspaces if user is admin (conditional query)
-  const { data: workspaces, isLoading: isWorkspacesLoading } =
-    trpc.workspaces.listWithDetails.useQuery(undefined, {
-      enabled: isSystemAdmin,
-      staleTime: 5 * 60 * 1000,
-    });
-
-  // Must define useCallback before early return (React hooks rules)
-  const handleWorkspaceSelect = useCallback(
+  const handleSelect = useCallback(
     (slug: string) => {
-      if (slug !== currentSlug) {
-        router.push(`/workspace/${slug}/settings`);
-      }
+      setOpen(false);
+      selectWorkspace(slug);
     },
-    [currentSlug, router]
+    [selectWorkspace]
   );
 
   const renderWorkspaceItem = useCallback(
     (workspace: WorkspaceListItem) => {
-      const isCurrentWorkspace = currentSlug ? workspace.slug === currentSlug : false;
+      const isCurrentWorkspace = currentSlug === workspace.slug;
       const Icon = workspace.isPersonal ? User : Building2;
 
-      const handleClick = () => handleWorkspaceSelect(workspace.slug);
+      const onSelect = () => handleSelect(workspace.slug);
 
       return (
-        <DropdownMenuItem
+        <CommandItem
           key={workspace.id}
-          onClick={handleClick}
+          value={workspace.name}
+          onSelect={onSelect}
           className="flex items-center justify-between gap-2 cursor-pointer"
         >
           <div className="flex items-center gap-2 min-w-0">
@@ -70,58 +65,60 @@ export function AdminWorkspaceSwitcher() {
           {isCurrentWorkspace && (
             <Check className="h-4 w-4 shrink-0 text-primary" />
           )}
-        </DropdownMenuItem>
+        </CommandItem>
       );
     },
-    [currentSlug, handleWorkspaceSelect]
+    [currentSlug, handleSelect]
   );
 
-  // Return null if not admin, still loading, or invalid slug
-  if (isAdminLoading || !isSystemAdmin || !currentSlug) {
+  if (!isSystemAdmin || !currentSlug) {
     return null;
   }
 
-  const currentWorkspace = workspaces?.find((w) => w.slug === currentSlug);
-  const isLoading = isWorkspacesLoading;
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="gap-2"
-          disabled={isLoading}
-        >
-          <Shield className="h-4 w-4 text-yellow-600" />
-          {isLoading ? (
-            "Loading..."
-          ) : currentWorkspace ? (
-            <>
-              <span className="max-w-[150px] truncate">
-                {currentWorkspace.name}
-              </span>
-              <ChevronsUpDown className="h-4 w-4 opacity-50" />
-            </>
-          ) : (
-            "Select workspace"
-          )}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-[220px]">
-        <DropdownMenuLabel className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Shield className="h-3 w-3" />
-          Admin: Switch Workspace
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {workspaces && workspaces.length > 0 ? (
-          workspaces.map(renderWorkspaceItem)
-        ) : (
-          <DropdownMenuItem disabled className="text-muted-foreground">
-            No workspaces available
-          </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div className="flex items-center gap-3">
+      <span className="text-xs font-medium text-muted-foreground">
+        Admin workspace view
+      </span>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            role="combobox"
+            aria-expanded={open}
+            className="gap-2"
+            disabled={isLoading}
+          >
+            <Shield className="h-4 w-4 text-yellow-600" />
+            {isLoading ? (
+              "Loading..."
+            ) : currentWorkspace ? (
+              <>
+                <span className="max-w-[150px] truncate">
+                  {currentWorkspace.name}
+                </span>
+                <ChevronsUpDown className="h-4 w-4 opacity-50" />
+              </>
+            ) : (
+              "Select workspace"
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[250px] p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search workspaces..." />
+            <CommandList>
+              <CommandEmpty>No workspace found.</CommandEmpty>
+              <CommandGroup heading="Admin: Switch Workspace">
+                {workspaces.length > 0
+                  ? workspaces.map(renderWorkspaceItem)
+                  : null}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
   );
 }

--- a/apps/web/src/hooks/use-admin-workspace-switcher.ts
+++ b/apps/web/src/hooks/use-admin-workspace-switcher.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import type { WorkspaceListItem } from "@ducsigr/api/client";
+
+import { trpc } from "@/lib/trpc/client";
+import { useSystemAdmin } from "@/hooks/use-system-admin";
+
+interface UseAdminWorkspaceSwitcherReturn {
+  isSystemAdmin: boolean;
+  isLoading: boolean;
+  currentSlug: string | undefined;
+  currentWorkspace: WorkspaceListItem | undefined;
+  workspaces: WorkspaceListItem[];
+  selectWorkspace: (slug: string) => void;
+}
+
+/**
+ * Hook that encapsulates admin workspace switcher logic.
+ * Fetches all workspaces for system admins and provides navigation.
+ */
+export function useAdminWorkspaceSwitcher(): UseAdminWorkspaceSwitcherReturn {
+  const params = useParams();
+  const router = useRouter();
+
+  const rawSlug = params.workspaceSlug;
+  const currentSlug = typeof rawSlug === "string" ? rawSlug : undefined;
+
+  const { isSystemAdmin, isLoading: isAdminLoading } = useSystemAdmin();
+
+  const { data: workspaces, isLoading: isWorkspacesLoading } =
+    trpc.workspaces.listWithDetails.useQuery(undefined, {
+      enabled: isSystemAdmin,
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const selectWorkspace = useCallback(
+    (slug: string) => {
+      if (slug !== currentSlug) {
+        router.push(`/workspace/${slug}/settings`);
+      }
+    },
+    [currentSlug, router]
+  );
+
+  const currentWorkspace = workspaces?.find((w) => w.slug === currentSlug);
+
+  return {
+    isSystemAdmin: !isAdminLoading && isSystemAdmin,
+    isLoading: isAdminLoading || isWorkspacesLoading,
+    currentSlug,
+    currentWorkspace,
+    workspaces: workspaces ?? [],
+    selectWorkspace,
+  };
+}

--- a/docs/specs/244_ADMIN_WORKSPACE_SWITCHER_SPEC.md
+++ b/docs/specs/244_ADMIN_WORKSPACE_SWITCHER_SPEC.md
@@ -2,18 +2,21 @@
 
 ## Overview
 
-Add a workspace switcher dropdown in the workspace settings page that is **only visible to system admins**. This allows admins to quickly switch between workspaces they manage while configuring settings.
+A workspace switcher inside the General settings page that is **only visible to system admins**. Allows admins to view and manage **any** workspace without needing membership, with a searchable dropdown for quick navigation.
 
 ## Problem Statement
 
-System administrators need to manage settings across multiple workspaces efficiently. Currently, they must navigate back to the dashboard, select a different workspace, then navigate to settings again. This creates friction for admin workflows.
+System administrators need to manage settings across multiple workspaces efficiently. Previously, admins had to be a member of every workspace and navigate back to the dashboard to switch. This created friction for admin workflows.
 
 ## Solution
 
-A dropdown component in the settings page header that:
+A searchable combobox component inside the "Workspace Information" card on the General settings page that:
 1. Only renders for users with `isSystemAdmin = true`
-2. Lists all workspaces the user belongs to
-3. Allows one-click navigation to another workspace's settings
+2. Lists **all** workspaces (not just ones the admin belongs to)
+3. Provides search/filter for quick lookup
+4. Allows one-click navigation to another workspace's settings
+
+System admins also bypass workspace membership checks across the entire application — both the server-side layout gate and all tRPC workspace middleware.
 
 ---
 
@@ -26,19 +29,18 @@ A dropdown component in the settings page header that:
 │                         DATA FLOW                                   │
 └─────────────────────────────────────────────────────────────────────┘
 
-  ┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
-  │   Settings       │     │  useSystemAdmin  │     │  tRPC Backend    │
-  │   Layout         │────▶│  Hook            │────▶│  checkSystemAdmin│
-  │                  │     │                  │     │                  │
-  └──────────────────┘     └──────────────────┘     └──────────────────┘
-           │                        │                        │
-           │                        │                        │
-           ▼                        ▼                        ▼
-  ┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
-  │   Admin          │     │  listWithDetails │     │   PostgreSQL     │
-  │   Workspace      │◀────│  (if admin)      │◀────│   User.isSystem  │
-  │   Switcher       │     │                  │     │   Admin          │
-  └──────────────────┘     └──────────────────┘     └──────────────────┘
+  ┌──────────────────┐     ┌──────────────────────────┐     ┌──────────────────┐
+  │   General        │     │  useAdminWorkspace       │     │  tRPC Backend    │
+  │   Settings Page  │────▶│  Switcher Hook           │────▶│  checkSystemAdmin│
+  │                  │     │                          │     │  listWithDetails │
+  └──────────────────┘     └──────────────────────────┘     └──────────────────┘
+           │                          │                              │
+           ▼                          ▼                              ▼
+  ┌──────────────────┐     ┌──────────────────┐     ┌──────────────────────────┐
+  │   Admin          │     │  useSystemAdmin  │     │   PostgreSQL             │
+  │   Workspace      │◀────│  Hook            │◀────│   User.isSystemAdmin     │
+  │   Switcher       │     │                  │     │   Workspace (all)        │
+  └──────────────────┘     └──────────────────┘     └──────────────────────────┘
 ```
 
 ### Security Model
@@ -48,251 +50,140 @@ A dropdown component in the settings page header that:
 | Frontend | Conditional render | Component returns `null` if not admin |
 | API | `protectedProcedure` | Requires authenticated session |
 | Database | `isSystemAdmin` check | Only returns `true` for admins |
-| Navigation | Workspace middleware | Still enforces membership on target workspace |
+| Workspace layout | System admin bypass | Admins can access any workspace without membership |
+| tRPC middleware | System admin bypass | `requireWorkspaceAccess` grants access to admins for any workspace |
 
-**Important:** The frontend check is cosmetic. System admins can only switch to workspaces they are members of - the workspace middleware enforces this on every page load.
+**System admin access flow:**
+1. `requireWorkspaceAccess` first checks session workspace memberships
+2. If no membership found, queries DB for `isSystemAdmin`
+3. If admin, resolves workspace directly and grants `ADMIN` role
+4. If not admin, throws `FORBIDDEN`
 
 ---
 
 ## Implementation Details
 
-### Phase 1: Backend - Add System Admin Check Procedure
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `packages/api/src/middleware/workspace.ts` | Workspace access checks with system admin bypass |
+| `packages/api/src/routers/workspaces.ts` | `checkSystemAdmin` + `listWithDetails` (all workspaces for admins) |
+| `apps/web/src/hooks/use-system-admin.ts` | Hook to check if current user is system admin |
+| `apps/web/src/hooks/use-admin-workspace-switcher.ts` | Hook with workspace fetching and navigation logic |
+| `apps/web/src/components/settings/admin-workspace-switcher.tsx` | Searchable combobox UI component |
+| `apps/web/src/app/workspace/[workspaceSlug]/settings/page.tsx` | General settings page (hosts the switcher) |
+| `apps/web/src/app/workspace/[workspaceSlug]/layout.tsx` | Workspace layout with system admin bypass |
+
+---
+
+### Backend: Workspace Middleware (System Admin Bypass)
+
+**File:** `packages/api/src/middleware/workspace.ts`
+
+`requireWorkspaceAccess` is async and checks `isSystemAdmin` when no membership is found:
+
+```typescript
+export async function requireWorkspaceAccess(
+  ctx: Context & { session: SessionWithWorkspaces },
+  workspaceIdOrSlug: string,
+  bySlug = false
+): Promise<WorkspaceAccess> {
+  // 1. Check session memberships first (fast path)
+  const access = bySlug
+    ? hasWorkspaceAccessBySlug(workspaces, workspaceIdOrSlug)
+    : hasWorkspaceAccess(workspaces, workspaceIdOrSlug);
+
+  if (access) return access;
+
+  // 2. No membership — check if system admin (DB query)
+  const user = await prisma.user.findUnique({
+    where: { id: ctx.session.user.id },
+    select: { isSystemAdmin: true },
+  });
+
+  if (user?.isSystemAdmin) {
+    // Resolve workspace and return synthetic ADMIN access
+    const workspace = await prisma.workspace.findUnique({ ... });
+    if (workspace) {
+      return { id: workspace.id, slug: workspace.slug, role: "ADMIN", isPersonal: workspace.isPersonal };
+    }
+  }
+
+  throw new TRPCError({ code: "FORBIDDEN" });
+}
+```
+
+This applies globally to all procedures using `workspaceMiddleware` or `workspaceAdminMiddleware`.
+
+---
+
+### Backend: listWithDetails (All Workspaces for Admins)
 
 **File:** `packages/api/src/routers/workspaces.ts`
 
-**Location:** After `checkApproval` procedure (approximately line 67)
-
-**Procedure Definition:**
-
 ```typescript
-/**
- * Check if the current user is a system admin.
- * Used to conditionally show admin-only features like workspace switcher.
- */
-checkSystemAdmin: protectedProcedure.query(async ({ ctx }): Promise<{ isSystemAdmin: boolean }> => {
-  const session = ctx.session as SessionWithWorkspaces;
-
+listWithDetails: protectedProcedure.query(async ({ ctx }) => {
+  // Check if system admin
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
     select: { isSystemAdmin: true },
   });
+  const isAdmin = user?.isSystemAdmin ?? false;
 
-  return { isSystemAdmin: user?.isSystemAdmin ?? false };
-}),
+  // Admins see ALL workspaces; regular users see only their own
+  const workspaces = await prisma.workspace.findMany({
+    where: isAdmin ? undefined : { members: { some: { userId: session.user.id } } },
+    // ...
+  });
+});
 ```
-
-**Rationale:**
-- Returns simple boolean object for easy consumption
-- Follows existing `checkApproval` pattern in same file
-- Uses `protectedProcedure` to ensure authenticated users only
-- Minimal database query (single field select)
 
 ---
 
-### Phase 2: Frontend Hook - useSystemAdmin
+### Frontend: Hook Architecture
 
-**File:** `apps/web/src/hooks/use-system-admin.ts`
+**`useSystemAdmin`** (`hooks/use-system-admin.ts`)
+- Calls `workspaces.checkSystemAdmin` tRPC query
+- Cached for 5 minutes, no refetch on window focus
+- Returns `{ isSystemAdmin, isLoading, error }`
+
+**`useAdminWorkspaceSwitcher`** (`hooks/use-admin-workspace-switcher.ts`)
+- Composes `useSystemAdmin` with workspace list fetching
+- Handles current workspace resolution from URL params
+- Provides `selectWorkspace(slug)` for navigation
+- Returns `{ isSystemAdmin, isLoading, currentSlug, currentWorkspace, workspaces, selectWorkspace }`
+
+---
+
+### Frontend: Component
+
+**`AdminWorkspaceSwitcher`** (`components/settings/admin-workspace-switcher.tsx`)
+- Consumes `useAdminWorkspaceSwitcher` hook (no data logic)
+- Uses `Popover` + `Command` (cmdk) for searchable combobox
+- Shows "Admin workspace view" label next to the trigger button
+- Shield icon with yellow color as admin indicator
+- Renders inside "Workspace Information" card on General settings page
+
+---
+
+### Workspace Layout: Admin Bypass
+
+**File:** `apps/web/src/app/workspace/[workspaceSlug]/layout.tsx`
 
 ```typescript
-"use client";
+// Check if user is a system admin
+const user = await prisma.user.findUnique({
+  where: { id: session.user.id },
+  select: { isSystemAdmin: true },
+});
+const isAdmin = user?.isSystemAdmin ?? false;
 
-import { trpc } from "@/lib/trpc/client";
-
-/**
- * Hook to check if the current user is a system admin.
- * Results are cached for 5 minutes to minimize API calls.
- */
-export function useSystemAdmin() {
-  const { data, isLoading, error } = trpc.workspaces.checkSystemAdmin.useQuery(
-    undefined,
-    {
-      staleTime: 5 * 60 * 1000, // Cache for 5 minutes
-      refetchOnWindowFocus: false,
-    }
-  );
-
-  return {
-    isSystemAdmin: data?.isSystemAdmin ?? false,
-    isLoading,
-    error: error as Error | null,
-  };
+// System admins can access any workspace, even without membership
+if (!membership && !isAdmin) {
+  notFound();
 }
 ```
-
-**Rationale:**
-- Encapsulates admin check logic for reuse
-- Aggressive caching (5 min) since admin status rarely changes
-- Defaults to `false` during loading (safe default)
-- `refetchOnWindowFocus: false` prevents unnecessary calls
-
----
-
-### Phase 3: Frontend Component - AdminWorkspaceSwitcher
-
-**File:** `apps/web/src/components/settings/admin-workspace-switcher.tsx`
-
-**Component Structure:**
-
-```typescript
-"use client";
-
-import { useParams, useRouter } from "next/navigation";
-import { Check, ChevronsUpDown, Building2, User, Shield } from "lucide-react";
-
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { trpc } from "@/lib/trpc/client";
-import { useSystemAdmin } from "@/hooks/use-system-admin";
-
-export function AdminWorkspaceSwitcher() {
-  const params = useParams();
-  const router = useRouter();
-  const currentSlug = params.workspaceSlug as string;
-
-  // Check if user is system admin
-  const { isSystemAdmin, isLoading: isAdminLoading } = useSystemAdmin();
-
-  // Only fetch workspaces if user is admin (conditional query)
-  const { data: workspaces, isLoading: isWorkspacesLoading } =
-    trpc.workspaces.listWithDetails.useQuery(undefined, {
-      enabled: isSystemAdmin, // Only fetch if admin
-      staleTime: 5 * 60 * 1000,
-    });
-
-  // Return null if not admin or still loading admin status
-  if (isAdminLoading || !isSystemAdmin) {
-    return null;
-  }
-
-  const currentWorkspace = workspaces?.find((w) => w.slug === currentSlug);
-  const isLoading = isWorkspacesLoading;
-
-  const handleWorkspaceSelect = (slug: string) => {
-    if (slug !== currentSlug) {
-      router.push(`/workspace/${slug}/settings`);
-    }
-  };
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="gap-2"
-          disabled={isLoading}
-        >
-          <Shield className="h-4 w-4 text-yellow-600" />
-          {isLoading ? (
-            "Loading..."
-          ) : currentWorkspace ? (
-            <>
-              <span className="max-w-[150px] truncate">
-                {currentWorkspace.name}
-              </span>
-              <ChevronsUpDown className="h-4 w-4 opacity-50" />
-            </>
-          ) : (
-            "Select workspace"
-          )}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-[220px]">
-        <DropdownMenuLabel className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Shield className="h-3 w-3" />
-          Admin: Switch Workspace
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {workspaces?.map((workspace) => {
-          const isCurrentWorkspace = workspace.slug === currentSlug;
-          const Icon = workspace.isPersonal ? User : Building2;
-
-          return (
-            <DropdownMenuItem
-              key={workspace.id}
-              onClick={() => handleWorkspaceSelect(workspace.slug)}
-              className="flex items-center justify-between gap-2"
-            >
-              <div className="flex items-center gap-2 min-w-0">
-                <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="truncate">{workspace.name}</span>
-              </div>
-              {isCurrentWorkspace && (
-                <Check className="h-4 w-4 shrink-0 text-primary" />
-              )}
-            </DropdownMenuItem>
-          );
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-```
-
-**Key Design Decisions:**
-
-| Decision | Rationale |
-|----------|-----------|
-| `enabled: isSystemAdmin` | Prevents API call if not admin |
-| Shield icon with yellow color | Visual indicator this is admin feature |
-| Returns `null` during loading | No UI flash for non-admins |
-| Same workspace item pattern | Consistent with existing `workspace-switcher.tsx` |
-| Truncation on names | Handles long workspace names gracefully |
-
----
-
-### Phase 4: Integration - Settings Layout
-
-**File:** `apps/web/src/app/workspace/[workspaceSlug]/settings/layout.tsx`
-
-**Changes Required:**
-
-1. Add import at top of file:
-```typescript
-import { AdminWorkspaceSwitcher } from "@/components/settings/admin-workspace-switcher";
-```
-
-2. Wrap existing content and add switcher:
-```typescript
-return (
-  <div className="space-y-6">
-    {/* Admin Workspace Switcher - Only shows for system admins */}
-    <div className="flex justify-end">
-      <AdminWorkspaceSwitcher />
-    </div>
-
-    <div className="flex gap-6">
-      {/* Existing sidebar */}
-      <aside className="w-48 shrink-0">
-        <SettingsSidebar />
-      </aside>
-
-      {/* Existing main content */}
-      <main className="flex-1 min-w-0">{children}</main>
-    </div>
-  </div>
-);
-```
-
----
-
-## File Summary
-
-| File | Action | Lines Changed |
-|------|--------|---------------|
-| `packages/api/src/routers/workspaces.ts` | Modify | +15 |
-| `apps/web/src/hooks/use-system-admin.ts` | Create | ~25 |
-| `apps/web/src/components/settings/admin-workspace-switcher.tsx` | Create | ~100 |
-| `apps/web/src/app/workspace/[workspaceSlug]/settings/layout.tsx` | Modify | +10 |
-
-**Total estimated changes:** ~150 lines
 
 ---
 
@@ -315,43 +206,34 @@ No database migrations required. The `isSystemAdmin` field already exists in the
 
 2. **Admin user tests:**
    - [ ] Navigate to `/workspace/{slug}/settings`
-   - [ ] Verify switcher appears in top-right corner
+   - [ ] Verify switcher appears inside "Workspace Information" card
+   - [ ] Verify "Admin workspace view" label is visible
    - [ ] Verify Shield icon is yellow
-   - [ ] Click dropdown - all user's workspaces listed
+   - [ ] Click dropdown — **all** workspaces listed (not just member workspaces)
+   - [ ] Type in search — filters workspaces by name
    - [ ] Current workspace has checkmark
-   - [ ] Click different workspace - navigates to its settings
-   - [ ] Personal workspace shows User icon
-   - [ ] Team workspace shows Building2 icon
+   - [ ] Click different workspace — navigates to its settings
+   - [ ] Navigate to a workspace admin is NOT a member of — page loads without errors
+   - [ ] tRPC queries (graphs, overview, etc.) work on non-member workspaces
 
 3. **Non-admin user tests:**
    - [ ] Navigate to `/workspace/{slug}/settings`
    - [ ] Verify switcher does NOT appear
    - [ ] No visual flash or loading state visible
+   - [ ] Navigating to a non-member workspace returns 404
 
 4. **Edge cases:**
-   - [ ] User with only one workspace - switcher still works
-   - [ ] Long workspace names - truncated properly
-   - [ ] Rapid clicking between workspaces - no race conditions
+   - [ ] User with only one workspace — switcher still works
+   - [ ] Long workspace names — truncated properly
+   - [ ] Rapid clicking between workspaces — no race conditions
+   - [ ] Search with no results — shows "No workspace found."
 
-### Automated Tests (Future)
+### Automated Tests
 
-```typescript
-// packages/api/src/routers/__tests__/workspaces.test.ts
-
-describe("checkSystemAdmin", () => {
-  it("returns true for system admin", async () => {
-    // Setup admin user
-    const result = await caller.workspaces.checkSystemAdmin();
-    expect(result.isSystemAdmin).toBe(true);
-  });
-
-  it("returns false for regular user", async () => {
-    // Setup regular user
-    const result = await caller.workspaces.checkSystemAdmin();
-    expect(result.isSystemAdmin).toBe(false);
-  });
-});
-```
+Tests in `packages/api/src/routers/__tests__/workspaces-system-admin.test.ts`:
+- Returns `true` for system admin
+- Returns `false` for regular user
+- Requires authentication
 
 ---
 
@@ -359,20 +241,10 @@ describe("checkSystemAdmin", () => {
 
 | Aspect | Mitigation |
 |--------|------------|
-| Extra API call for admin check | Cached for 5 minutes |
-| Workspace list fetch | Conditional - only if admin |
+| Admin check API call | Cached for 5 minutes |
+| Workspace list fetch | Conditional — only if admin |
 | Component render | Returns `null` early for non-admins |
-
-**Expected impact:** Negligible. One additional small query for authenticated users, cached aggressively.
-
----
-
-## Future Enhancements
-
-1. **Show all workspaces for super-admins** - Currently only shows workspaces user belongs to
-2. **Quick actions per workspace** - Could add sub-menus for common actions
-3. **Search/filter** - For users with many workspaces
-4. **Keyboard navigation** - Ctrl+K style workspace search
+| Middleware DB query | Only triggered when no session membership found |
 
 ---
 
@@ -381,24 +253,7 @@ describe("checkSystemAdmin", () => {
 If issues arise, the feature can be disabled by:
 
 1. **Quick fix:** Return `null` from `AdminWorkspaceSwitcher` component
-2. **Full rollback:** Revert all 4 files to previous state
+2. **Middleware rollback:** Revert `requireWorkspaceAccess` to synchronous membership-only check
+3. **Full rollback:** Revert all changed files to previous state
 
 No database changes required for rollback.
-
----
-
-## Approval Checklist
-
-- [ ] Security review - admin check pattern approved
-- [ ] UX review - placement and interaction approved
-- [ ] Code review - follows project patterns
-- [ ] Testing - manual tests passed
-- [ ] Documentation - spec complete
-
----
-
-## References
-
-- **Similar patterns:** `apps/web/src/components/workspace-switcher.tsx` (workspace rendering)
-- **Auth pattern:** `packages/api/src/routers/workspaces.ts:checkApproval` (DB query pattern)
-- **Protected procedure:** `packages/api/src/trpc.ts` (authentication)

--- a/packages/api/src/middleware/workspace.ts
+++ b/packages/api/src/middleware/workspace.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import { prisma } from "@ducsigr/db";
 import type {
   Context,
   SessionWithWorkspaces,
@@ -41,35 +42,65 @@ export function hasWorkspaceRole(
 /**
  * Throws FORBIDDEN if user doesn't have access to workspace.
  * Supports both ID and slug lookup.
+ * System admins bypass membership checks and can access any workspace.
  */
-export function requireWorkspaceAccess(
+export async function requireWorkspaceAccess(
   ctx: Context & { session: SessionWithWorkspaces },
   workspaceIdOrSlug: string,
   bySlug = false
-): WorkspaceAccess {
+): Promise<WorkspaceAccess> {
   const workspaces = ctx.session.user.workspaces;
   const access = bySlug
     ? hasWorkspaceAccessBySlug(workspaces, workspaceIdOrSlug)
     : hasWorkspaceAccess(workspaces, workspaceIdOrSlug);
 
-  if (!access) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "You don't have access to this workspace",
-    });
+  if (access) {
+    return access;
   }
-  return access;
+
+  // No membership — check if user is a system admin
+  const user = await prisma.user.findUnique({
+    where: { id: ctx.session.user.id },
+    select: { isSystemAdmin: true },
+  });
+
+  if (user?.isSystemAdmin) {
+    // Resolve workspace to build a synthetic WorkspaceAccess
+    const workspace = bySlug
+      ? await prisma.workspace.findUnique({
+          where: { slug: workspaceIdOrSlug },
+          select: { id: true, slug: true, isPersonal: true },
+        })
+      : await prisma.workspace.findUnique({
+          where: { id: workspaceIdOrSlug },
+          select: { id: true, slug: true, isPersonal: true },
+        });
+
+    if (workspace) {
+      return {
+        id: workspace.id,
+        slug: workspace.slug,
+        role: "ADMIN",
+        isPersonal: workspace.isPersonal,
+      };
+    }
+  }
+
+  throw new TRPCError({
+    code: "FORBIDDEN",
+    message: "You don't have access to this workspace",
+  });
 }
 
 /**
  * Throws FORBIDDEN if user doesn't have required role in workspace.
  */
-export function requireWorkspaceRole(
+export async function requireWorkspaceRole(
   ctx: Context & { session: SessionWithWorkspaces },
   workspaceId: string,
   allowedRoles: string[]
-): WorkspaceAccess {
-  const access = requireWorkspaceAccess(ctx, workspaceId);
+): Promise<WorkspaceAccess> {
+  const access = await requireWorkspaceAccess(ctx, workspaceId);
   if (!allowedRoles.includes(access.role)) {
     throw new TRPCError({
       code: "FORBIDDEN",

--- a/packages/api/src/routers/workspaces.ts
+++ b/packages/api/src/routers/workspaces.ts
@@ -103,16 +103,21 @@ export const workspacesRouter = createRouter({
 
   /**
    * List workspaces with full details (requires DB query).
+   * System admins see ALL workspaces; regular users see only their own.
    */
   listWithDetails: protectedProcedure.query(async ({ ctx }): Promise<WorkspaceListItem[]> => {
     const session = ctx.session as SessionWithWorkspaces;
 
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { isSystemAdmin: true },
+    });
+    const isAdmin = user?.isSystemAdmin ?? false;
+
     const workspaces = await prisma.workspace.findMany({
-      where: {
-        members: {
-          some: { userId: session.user.id },
-        },
-      },
+      where: isAdmin
+        ? undefined
+        : { members: { some: { userId: session.user.id } } },
       include: {
         members: {
           where: { userId: session.user.id },
@@ -127,7 +132,7 @@ export const workspacesRouter = createRouter({
       name: w.name,
       slug: w.slug,
       isPersonal: w.isPersonal,
-      role: w.members[0]?.role ?? "MEMBER",
+      role: w.members[0]?.role ?? (isAdmin ? "ADMIN" : "MEMBER"),
     }));
   }),
 

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -172,8 +172,8 @@ export const workspaceMiddleware = middleware(async ({ ctx, next, getRawInput })
     });
   }
 
-  // Check workspace access
-  const workspace = requireWorkspaceAccess(
+  // Check workspace access (async — supports system admin bypass)
+  const workspace = await requireWorkspaceAccess(
     ctx as Context & { session: SessionWithWorkspaces },
     identifier,
     bySlug
@@ -218,8 +218,8 @@ export const workspaceAdminMiddleware = middleware(async ({ ctx, next, getRawInp
     });
   }
 
-  // Check admin role
-  requireWorkspaceRole(
+  // Check admin role (async — supports system admin bypass)
+  await requireWorkspaceRole(
     ctx as Context & { session: SessionWithWorkspaces },
     input.workspaceId,
     [...WORKSPACE_ADMIN_ROLES]


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors workspace switching for system admins:

- Web: Moves the admin workspace switcher into the General settings page and updates the UI to a searchable combobox (`Popover` + `Command`) powered by a new `useAdminWorkspaceSwitcher` hook.
- Auth UX: Standardizes sign-out behavior to `signOut({ redirect: false })` followed by a hard navigation to `/login`.
- API: Adds a system-admin bypass to workspace access checks so admins can access any workspace even without membership. `listWithDetails` is updated so system admins can query all workspaces.

This fits into the codebase by extending the existing workspace access model (session membership + middleware enforcement) with a system-admin override both in the Next.js workspace layout gate and in tRPC workspace middleware, enabling the new cross-workspace settings navigation for admins.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable only after fixing one correctness issue around admin workspace role reporting.
- Core refactor is straightforward, but `listWithDetails` currently reports a synthetic ADMIN role for system admins on workspaces where they have no membership, which can mislead the client and any downstream logic relying on membership roles. Additional changes (async workspace middleware and logout redirect changes) look consistent but should be verified with integration tests.
- packages/api/src/routers/workspaces.ts; apps/web/src/components/auth/user-menu.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/workspace/[workspaceSlug]/layout.tsx | Adds system-admin bypass for workspace access in the server layout (fetches isSystemAdmin, allows non-member access, synthesizes ADMIN role). |
| apps/web/src/app/workspace/[workspaceSlug]/settings/layout.tsx | Removes admin switcher from settings layout; settings nav rendering unchanged. |
| apps/web/src/app/workspace/[workspaceSlug]/settings/page.tsx | Embeds AdminWorkspaceSwitcher into General settings card and adjusts spacing. |
| apps/web/src/components/auth/user-menu.tsx | Changes logout to signOut({redirect:false}) then hard-navigate to /login; introduces inline async JSX handler. |
| apps/web/src/components/layout/nav-user.tsx | Refactors sign-out handler to async signOut({redirect:false}) then window.location.href to /login. |
| apps/web/src/components/logout-button.tsx | Refactors sign-out to async signOut({redirect:false}) then window.location.href to /login. |
| apps/web/src/components/settings/admin-workspace-switcher.tsx | Refactors admin switcher UI to searchable combobox (Popover+Command) and delegates logic to new useAdminWorkspaceSwitcher hook. |
| apps/web/src/hooks/use-admin-workspace-switcher.ts | New client hook that composes useSystemAdmin with listWithDetails query and router navigation for workspace switching. |
| docs/specs/244_ADMIN_WORKSPACE_SWITCHER_SPEC.md | Updates spec to reflect searchable combobox placement and new system-admin bypass behavior. |
| packages/api/src/middleware/workspace.ts | Makes requireWorkspaceAccess/Role async and adds system-admin DB-backed bypass that synthesizes ADMIN access for any workspace. |
| packages/api/src/routers/workspaces.ts | Updates listWithDetails to return all workspaces for system admins; role fallback becomes ADMIN for non-member workspaces (misleading). |
| packages/api/src/trpc.ts | Updates workspace middleware to await async requireWorkspaceAccess/Role to support system-admin bypass. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant U as Admin User
  participant W as Web (Next.js)
  participant A as NextAuth
  participant API as tRPC API
  participant MW as Workspace Middleware
  participant DB as PostgreSQL (Prisma)

  U->>W: Navigate /workspace/{slug}/settings
  W->>A: getServerSession(authOptions)
  A-->>W: session.user.id
  W->>DB: workspaceMember.findFirst(userId, workspaceSlug)
  alt Membership found
    DB-->>W: membership + workspace
    W-->>U: Render settings (workspace role from membership)
  else No membership
    W->>DB: user.findUnique(select isSystemAdmin)
    DB-->>W: isSystemAdmin?
    alt isSystemAdmin
      W->>DB: workspace.findUnique(where slug)
      DB-->>W: workspace
      W-->>U: Render settings (synthetic role=ADMIN)
    else not admin
      W-->>U: 404 (notFound)
    end
  end

  U->>W: Open AdminWorkspaceSwitcher
  W->>API: workspaces.checkSystemAdmin()
  API->>DB: user.findUnique(select isSystemAdmin)
  DB-->>API: isSystemAdmin
  API-->>W: { isSystemAdmin }
  alt isSystemAdmin
    W->>API: workspaces.listWithDetails()
    API->>DB: user.findUnique(select isSystemAdmin)
    API->>DB: workspace.findMany(all workspaces)
    DB-->>API: workspaces
    API-->>W: WorkspaceListItem[]
    U->>W: Select workspace
    W-->>U: router.push(/workspace/{newSlug}/settings)
  else not admin
    W-->>U: Switcher hidden
  end

  U->>API: workspace-scoped query/mutation (workspaceId or workspaceSlug)
  API->>MW: workspaceMiddleware/workspaceAdminMiddleware
  MW->>DB: if no session membership, user.findUnique(isSystemAdmin)
  alt isSystemAdmin
    MW->>DB: workspace.findUnique(id/slug)
    DB-->>MW: workspace
    MW-->>API: ctx.workspace = synthetic ADMIN access
  else not admin
    MW-->>API: FORBIDDEN
  end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=62661dfd-5493-4dfb-b1ef-da76c03a640d))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=104053a9-4e3b-4a4a-916b-c37cc11512a9))

<!-- /greptile_comment -->