### PR TITLE
chore: enhance senior-architect skill with code skeletons & .md spec output

### DIFF
--- a/.claude/skills/senior-architect/SKILL.md
+++ b/.claude/skills/senior-architect/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: senior-architect
-description: Ducsigr software architect for designing scalable features following strict project conventions. Uses tRPC, Prisma, Zod schemas, Temporal workers, and React/Next.js patterns. Produces structured implementation plans with database, API, tests, and frontend specifications.
+description: Ducsigr software architect for designing scalable features following strict project conventions. Uses tRPC, Prisma, Zod schemas, Temporal workers, and React/Next.js patterns. Produces detailed engineering specifications with code skeletons, resource mapping, and rationale in .md format.
 ---
 
 # Ducsigr Senior Architect
 
-Design features and system architecture following Ducsigr's strict conventions. Produce implementation plans that can be executed by specialized agents.
+Design features and system architecture following Ducsigr's strict conventions. Produce **detailed engineering specifications** with code skeletons, codebase resource mapping, and architectural rationale - output as `.md` files that can be validated and executed by other agents.
 
 ## Quick Reference
 
@@ -137,47 +137,6 @@ export class FeatureService {
 | **UI** | shadcn/ui components only |
 | **Handlers** | Extract to named functions with `useCallback` |
 
-**Hook Pattern:**
-```typescript
-// apps/web/src/hooks/use-{domain}.ts
-export function useFeatures(workspaceId: string) {
-  const utils = trpc.useUtils();
-
-  const { data, isLoading } = trpc.features.list.useQuery({ workspaceId });
-
-  const createMutation = trpc.features.create.useMutation({
-    onSuccess: () => {
-      featureToast.created();
-      utils.features.list.invalidate({ workspaceId });
-    },
-    onError: showError,
-  });
-
-  const createFeature = useCallback(async (input) => {
-    await createMutation.mutateAsync({ ...input, workspaceId });
-  }, [createMutation, workspaceId]);
-
-  return { features: data?.items ?? [], isLoading, createFeature };
-}
-```
-
-**Component Pattern:**
-```typescript
-// apps/web/src/components/{domain}/{name}.tsx
-export function FeatureList({ workspaceId }: Props) {
-  const { features, isLoading, createFeature } = useFeatures(workspaceId);
-
-  // Extract ALL handlers (no inline functions)
-  const handleCreate = useCallback(async (data) => {
-    await createFeature(data);
-  }, [createFeature]);
-
-  if (isLoading) return <Skeleton />;
-
-  return <FeatureTable features={features} onCreate={handleCreate} />;
-}
-```
-
 ### 5. Temporal Worker Pattern
 
 **Activities are READ-ONLY. Mutations go through tRPC internal caller.**
@@ -218,104 +177,529 @@ export async function createFeature(input: CreateInput) {
 
 ---
 
-## Plan Output Format
-
-When designing a feature, output a structured plan:
-
-```json
-{
-  "feature": "Feature Name",
-  "summary": "One-line description",
-
-  "database": {
-    "schemaFile": "packages/db/prisma/schema/{domain}.prisma",
-    "models": [
-      {
-        "name": "Feature",
-        "fields": ["id String @id", "name String", "workspaceId String"],
-        "relations": ["workspace Workspace @relation(...)"]
-      }
-    ],
-    "migrationName": "add_features"
-  },
-
-  "schemas": {
-    "file": "packages/api/src/schemas/{domain}.ts",
-    "exports": [
-      { "name": "FeatureTypeSchema", "type": "enum", "values": ["A", "B"] },
-      { "name": "CreateFeatureInputSchema", "type": "object" }
-    ]
-  },
-
-  "api": {
-    "routerFile": "packages/api/src/routers/{domain}.ts",
-    "procedures": [
-      { "name": "list", "type": "query", "middleware": "workspaceMiddleware" },
-      { "name": "create", "type": "mutation", "middleware": "workspaceAdminMiddleware" }
-    ],
-    "serviceFile": "packages/api/src/services/{domain}.service.ts"
-  },
-
-  "tests": {
-    "file": "packages/api/src/routers/__tests__/{domain}.test.ts",
-    "testCases": [
-      "returns list of features",
-      "creates feature with valid input",
-      "requires authentication",
-      "requires admin role for mutations"
-    ]
-  },
-
-  "frontend": {
-    "hook": {
-      "file": "apps/web/src/hooks/use-{domain}.ts",
-      "operations": ["list", "create", "update", "delete"]
-    },
-    "components": [
-      { "file": "apps/web/src/components/{domain}/{name}-list.tsx" },
-      { "file": "apps/web/src/components/{domain}/create-{name}-dialog.tsx" }
-    ],
-    "toasts": {
-      "file": "apps/web/src/lib/success.ts",
-      "additions": ["featureToast.created()", "featureToast.updated()"]
-    }
-  },
-
-  "executionOrder": [
-    "1. Database schema + migration",
-    "2. Zod schemas (packages/api/src/schemas/)",
-    "3. Write tests (TDD)",
-    "4. Implement service + router",
-    "5. Register router in index.ts",
-    "6. Create hook",
-    "7. Build components",
-    "8. Add toast utilities"
-  ]
-}
-```
-
----
-
-## Workflow
+## Workflow (STRICT)
 
 1. **Understand Requirements** - Clarify if ambiguous
-2. **Explore Codebase** - Find similar patterns to follow
-3. **Design Solution** - Apply conventions strictly
-4. **Output Plan** - JSON format for executor agents
-5. **Confirm** - Ask user to approve or adjust
+2. **Explore Codebase** - Find similar patterns, existing files, related code
+3. **Map Resources** - Identify ALL existing files that relate to the feature
+4. **Design Solution** - Apply conventions strictly
+5. **Output Spec** - Write `.md` spec to `docs/specs/{feature-name}.md`
+6. **Confirm** - Ask user to approve or adjust
 
-After outputting the plan, always ask:
-> **"Plan complete! Next steps:"**
+After outputting the spec, always ask:
+> **"Spec complete! Next steps:"**
 > - `/execute` - Start implementation
 > - `/create-ticket` - Create GitHub issues
 > - Or describe adjustments needed
 
 ---
 
+## Spec Output Format (MANDATORY)
+
+**Every spec MUST be written as a `.md` file saved to `docs/specs/`.**
+
+The spec has 7 mandatory sections. Each section serves a purpose for downstream agents:
+
+### Spec Template
+
+````markdown
+# {Feature Name} - Engineering Specification
+
+**Date:** {YYYY-MM-DD}
+**Author:** Senior Architect (Claude)
+**Status:** Draft
+**Estimated Complexity:** {Low | Medium | High}
+
+---
+
+## 1. Overview
+
+### Summary
+{1-2 sentence description of what this feature does and why it matters.}
+
+### Acceptance Criteria
+- [ ] {Criterion 1}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+---
+
+## 2. Codebase Resource Map
+
+**This section shows the architect UNDERSTANDS the existing codebase.**
+
+### Existing Files (Related)
+| File | Purpose | Relevance |
+|------|---------|-----------|
+| `packages/api/src/routers/trace.ts` | Trace tRPC router | Similar pattern to follow |
+| `packages/api/src/schemas/trace.ts` | Trace Zod schemas | Enum/schema pattern to reuse |
+| `apps/web/src/hooks/use-traces.ts` | Trace hooks | Hook pattern to follow |
+| `apps/web/src/lib/success.ts` | Toast utilities | Add new toast entries here |
+| `apps/web/src/lib/errors.ts` | Error utilities | Add new error entries here |
+
+### Files to Create
+| File | Purpose |
+|------|---------|
+| `packages/api/src/schemas/{domain}.ts` | Zod schemas for this feature |
+| `packages/api/src/routers/{domain}.ts` | tRPC router |
+| `packages/api/src/services/{domain}.service.ts` | Business logic |
+| `packages/api/src/routers/__tests__/{domain}.test.ts` | Unit tests |
+| `apps/web/src/hooks/use-{domain}.ts` | Frontend hook |
+| `apps/web/src/components/{domain}/{name}.tsx` | UI components |
+
+### Files to Modify
+| File | Change |
+|------|--------|
+| `packages/api/src/routers/index.ts` | Register new router |
+| `apps/web/src/lib/success.ts` | Add `{domain}Toast` entries |
+| `apps/web/src/lib/errors.ts` | Add `{domain}Error` entries |
+| `packages/db/prisma/schema/{domain}.prisma` | New model (if needed) |
+
+---
+
+## 3. Rationale & Design Decisions
+
+**This section explains WHY this approach is good.**
+
+### Why This Architecture?
+{Explain the chosen approach and WHY it fits Ducsigr's patterns. Reference existing
+similar features that prove this pattern works.}
+
+### Alternatives Considered
+| Approach | Pros | Cons | Verdict |
+|----------|------|------|---------|
+| {Approach A} | {Pros} | {Cons} | **Chosen** - {reason} |
+| {Approach B} | {Pros} | {Cons} | Rejected - {reason} |
+
+### Key Design Choices
+1. **{Choice 1}** - {Why this over alternative}
+2. **{Choice 2}** - {Why this over alternative}
+
+---
+
+## 4. Database Schema
+
+### Prisma Model
+
+```prisma
+// packages/db/prisma/schema/{domain}.prisma
+
+model Feature {
+  id          String   @id @default(cuid())
+  name        String
+  type        FeatureType
+  workspaceId String
+  createdById String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  createdBy   User      @relation(fields: [createdById], references: [id])
+
+  @@index([workspaceId])
+  @@map("features")
+}
+
+enum FeatureType {
+  TYPE_A
+  TYPE_B
+}
+```
+
+**Migration command:**
+```bash
+pnpm db:migrate --name add_features_table
+```
+
+---
+
+## 5. API Layer (Code Skeletons)
+
+### 5.1 Zod Schemas
+
+```typescript
+// packages/api/src/schemas/{domain}.ts
+import { z } from "zod";
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// ENUMS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const FEATURE_TYPES = ["TYPE_A", "TYPE_B"] as const;
+export const FeatureTypeSchema = z.enum(FEATURE_TYPES);
+export type FeatureType = z.infer<typeof FeatureTypeSchema>;
+
+export const FEATURE_TYPE_LABELS: Record<FeatureType, string> = {
+  TYPE_A: "Type A",
+  TYPE_B: "Type B",
+};
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// INPUT SCHEMAS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const CreateFeatureInputSchema = z.object({
+  workspaceId: z.string(),
+  name: z.string().min(1).max(100),
+  type: FeatureTypeSchema,
+});
+export type CreateFeatureInput = z.infer<typeof CreateFeatureInputSchema>;
+
+export const ListFeaturesInputSchema = z.object({
+  workspaceId: z.string(),
+  type: FeatureTypeSchema.optional(),
+  limit: z.number().min(1).max(100).default(50),
+  offset: z.number().min(0).default(0),
+});
+export type ListFeaturesInput = z.infer<typeof ListFeaturesInputSchema>;
+
+// Add to packages/api/src/schemas/index.ts:
+// export * from "./{domain}";
+```
+
+### 5.2 Service Layer
+
+```typescript
+// packages/api/src/services/{domain}.service.ts
+import { TRPCError } from "@trpc/server";
+import { prisma } from "@ducsigr/db";
+import type { CreateFeatureInput, ListFeaturesInput } from "../schemas/{domain}";
+
+export class FeatureService {
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  // PUBLIC METHODS
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  static async list(input: ListFeaturesInput) {
+    const { workspaceId, type, limit, offset } = input;
+    const where = { workspaceId, ...(type && { type }) };
+
+    const [items, total] = await Promise.all([
+      prisma.feature.findMany({
+        where,
+        take: limit,
+        skip: offset,
+        orderBy: { createdAt: "desc" },
+      }),
+      prisma.feature.count({ where }),
+    ]);
+
+    return { items, total };
+  }
+
+  static async create(input: CreateFeatureInput, userId: string) {
+    // TODO: Add duplicate check if needed
+    return prisma.feature.create({
+      data: { ...input, createdById: userId },
+    });
+  }
+
+  static async delete(id: string) {
+    try {
+      await prisma.feature.delete({ where: { id } });
+    } catch (error) {
+      if ((error as { code?: string }).code === "P2025") {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Feature not found" });
+      }
+      throw error;
+    }
+  }
+}
+```
+
+### 5.3 tRPC Router
+
+```typescript
+// packages/api/src/routers/{domain}.ts
+import { z } from "zod";
+import {
+  createTRPCRouter,
+  protectedProcedure,
+  workspaceMiddleware,
+  workspaceAdminMiddleware,
+} from "../trpc";
+import {
+  CreateFeatureInputSchema,
+  ListFeaturesInputSchema,
+} from "../schemas/{domain}";
+import { FeatureService } from "../services/{domain}.service";
+
+export const featuresRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(ListFeaturesInputSchema)
+    .use(workspaceMiddleware)
+    .query(async ({ input }) => {
+      return FeatureService.list(input);
+    }),
+
+  create: protectedProcedure
+    .input(CreateFeatureInputSchema)
+    .use(workspaceAdminMiddleware)
+    .mutation(async ({ ctx, input }) => {
+      return FeatureService.create(input, ctx.session.user.id);
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .use(workspaceAdminMiddleware)
+    .mutation(async ({ input }) => {
+      return FeatureService.delete(input.id);
+    }),
+});
+
+// Register in packages/api/src/routers/index.ts:
+// features: featuresRouter,
+```
+
+---
+
+## 6. Frontend Layer (Code Skeletons)
+
+### 6.1 Domain Hook
+
+```typescript
+// apps/web/src/hooks/use-{domain}.ts
+"use client";
+
+import { useCallback } from "react";
+import { trpc } from "@/lib/trpc";
+import { showError } from "@/lib/errors";
+import { featureToast } from "@/lib/success";
+import type { CreateFeatureInput } from "@ducsigr/api/schemas";
+
+export function useFeatures(workspaceId: string) {
+  const utils = trpc.useUtils();
+
+  const { data, isLoading, error } = trpc.features.list.useQuery(
+    { workspaceId },
+    { staleTime: 30_000 }
+  );
+
+  const createMutation = trpc.features.create.useMutation({
+    onSuccess: (result) => {
+      featureToast.created(result.name);
+      utils.features.list.invalidate({ workspaceId });
+    },
+    onError: showError,
+  });
+
+  const deleteMutation = trpc.features.delete.useMutation({
+    onSuccess: () => {
+      featureToast.deleted();
+      utils.features.list.invalidate({ workspaceId });
+    },
+    onError: showError,
+  });
+
+  const createFeature = useCallback(
+    async (input: Omit<CreateFeatureInput, "workspaceId">) => {
+      await createMutation.mutateAsync({ ...input, workspaceId });
+    },
+    [createMutation, workspaceId]
+  );
+
+  const deleteFeature = useCallback(
+    async (id: string) => {
+      await deleteMutation.mutateAsync({ id });
+    },
+    [deleteMutation]
+  );
+
+  return {
+    features: data?.items ?? [],
+    total: data?.total ?? 0,
+    isLoading,
+    error: error ?? null,
+    createFeature,
+    deleteFeature,
+    isCreating: createMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+  };
+}
+```
+
+### 6.2 Component Skeleton
+
+```typescript
+// apps/web/src/components/{domain}/{domain}-list.tsx
+"use client";
+
+import { useState, useCallback } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useFeatures } from "@/hooks/use-{domain}";
+
+interface FeatureListProps {
+  workspaceId: string;
+}
+
+export function FeatureList({ workspaceId }: FeatureListProps) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const { features, isLoading, createFeature, isCreating } = useFeatures(workspaceId);
+
+  const handleOpenCreate = useCallback(() => setCreateOpen(true), []);
+  const handleCloseCreate = useCallback(() => setCreateOpen(false), []);
+
+  // TODO: Implement loading skeleton, empty state, table, create dialog
+  // Follow pattern from: apps/web/src/components/{similar-domain}/
+}
+```
+
+### 6.3 Toast Additions
+
+```typescript
+// Add to apps/web/src/lib/success.ts:
+export const featureToast = {
+  created: (name: string) =>
+    toast.success("Feature Created", { description: `"${name}" has been created.` }),
+  updated: (name?: string) =>
+    toast.success("Feature Updated", { description: name ? `"${name}" updated.` : undefined }),
+  deleted: (name?: string) =>
+    toast.success("Feature Deleted", { description: name ? `"${name}" deleted.` : undefined }),
+} as const;
+
+// Add to apps/web/src/lib/errors.ts:
+export const featureError = {
+  notFound: () =>
+    toast.error("Feature Not Found", { description: "This feature doesn't exist." }),
+} as const;
+```
+
+---
+
+## 7. Test Specifications
+
+### Unit Tests
+
+```typescript
+// packages/api/src/routers/__tests__/{domain}.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+vi.mock("@ducsigr/db", () => ({
+  prisma: {
+    feature: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    $transaction: vi.fn((fn) => fn(prisma)),
+  },
+}));
+
+import { prisma } from "@ducsigr/db";
+
+// Fixtures
+const MOCK_USER = { id: "user_123", name: "Test User", email: "test@example.com" };
+const MOCK_WORKSPACE = { id: "ws_123", slug: "test-workspace", role: "OWNER" };
+const MOCK_SESSION = { user: MOCK_USER, workspaces: [MOCK_WORKSPACE] };
+
+describe("{domain}Router", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  describe("list", () => {
+    it("returns paginated list of features", async () => {
+      // TODO: Implement - follow pattern from trace.test.ts
+    });
+
+    it("filters by type when provided", async () => {
+      // TODO: Implement
+    });
+
+    it("requires authentication", async () => {
+      // TODO: Implement - expect TRPCError UNAUTHORIZED
+    });
+  });
+
+  describe("create", () => {
+    it("creates feature with valid input", async () => {
+      // TODO: Implement
+    });
+
+    it("requires admin role", async () => {
+      // TODO: Implement - expect TRPCError FORBIDDEN for MEMBER role
+    });
+
+    it("validates input schema", async () => {
+      // TODO: Implement - empty name, invalid type
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes existing feature", async () => {
+      // TODO: Implement
+    });
+
+    it("throws NOT_FOUND for missing feature", async () => {
+      // TODO: Implement - mock P2025 error
+    });
+  });
+});
+```
+
+---
+
+## 8. Execution Order
+
+| Step | Action | Files | Depends On |
+|------|--------|-------|------------|
+| 1 | Database schema + migration | `packages/db/prisma/schema/{domain}.prisma` | - |
+| 2 | Zod schemas | `packages/api/src/schemas/{domain}.ts` | Step 1 |
+| 3 | Write tests (TDD) | `packages/api/src/routers/__tests__/{domain}.test.ts` | Step 2 |
+| 4 | Implement service | `packages/api/src/services/{domain}.service.ts` | Step 2 |
+| 5 | Implement router + register | `packages/api/src/routers/{domain}.ts`, `index.ts` | Step 4 |
+| 6 | Run tests, verify passing | - | Step 3, 5 |
+| 7 | Create hook | `apps/web/src/hooks/use-{domain}.ts` | Step 5 |
+| 8 | Build components | `apps/web/src/components/{domain}/` | Step 7 |
+| 9 | Add toast utilities | `apps/web/src/lib/success.ts`, `errors.ts` | Step 8 |
+````
+
+---
+
+## Spec Quality Checklist
+
+Before outputting any spec, verify ALL of these:
+
+### Resource Awareness
+- [ ] Listed ALL existing files that are related to this feature
+- [ ] Showed which existing patterns to follow (with file paths)
+- [ ] Identified which existing files need modification
+- [ ] Cited similar features already in the codebase as precedent
+
+### Code Skeletons
+- [ ] Prisma model with relations and indexes
+- [ ] Zod schemas with enums extracted to `as const` arrays
+- [ ] Service class with static methods
+- [ ] Thin tRPC router delegating to service
+- [ ] Frontend hook with query + mutations
+- [ ] Component skeleton with handler extraction
+- [ ] Toast/error additions
+- [ ] Test file with describe/it structure
+
+### Rationale
+- [ ] Explained WHY this architecture was chosen
+- [ ] Listed alternatives that were considered and why they were rejected
+- [ ] Referenced existing similar features as proof the pattern works
+- [ ] Called out any non-obvious design decisions
+
+### Executability
+- [ ] Every code skeleton compiles (correct imports, types)
+- [ ] Execution order is explicit with dependencies
+- [ ] Migration command is specified
+- [ ] Registration steps (router index, schema index) are noted
+- [ ] Another agent can implement this spec without asking questions
+
+---
+
 ## Reference Documentation
 
 - `references/architecture_patterns.md` - General architecture patterns
-- `references/ducsigr_conventions.md` - Ducsigr-specific patterns
+- `references/cognobserve_conventions.md` - Ducsigr-specific patterns
 - `references/tech_decision_guide.md` - Technology decisions
 - `references/system_design_workflows.md` - Design workflows
 
@@ -333,3 +717,6 @@ After outputting the plan, always ask:
 | Check-then-act DB operations | Use atomic operations |
 | Fat components (> 150 lines) | Split into smaller components |
 | Direct mutations in Temporal activities | Use tRPC internal caller |
+| Spec without code skeletons | ALWAYS include compilable code |
+| Spec without resource map | ALWAYS show existing file awareness |
+| Spec without rationale | ALWAYS explain WHY, not just WHAT |


### PR DESCRIPTION
## Summary
- Updated the `senior-architect` skill to produce detailed `.md` engineering specifications instead of JSON plans
- Specs now include **codebase resource mapping** (existing files, files to create/modify) showing the architect understands where things live
- Added **architectural rationale** section explaining WHY the approach is good, with alternatives considered
- Added **compilable code skeletons** for every layer: Prisma models, Zod schemas, service classes, tRPC routers, frontend hooks, components, toast/error entries, and test structures
- Added **spec quality checklist** ensuring resource awareness, code skeletons, rationale, and executability
- Output format is `.md` files saved to `docs/specs/` — consumable by downstream validation and executor agents

## Test plan
- [ ] Invoke `/plan` or `senior-architect` skill and verify the output follows the new `.md` spec template
- [ ] Confirm the spec includes all 7 mandatory sections (Overview, Resource Map, Rationale, DB Schema, API Layer, Frontend Layer, Tests)
- [ ] Verify code skeletons are compilable TypeScript with correct imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Enhanced the `senior-architect` skill to generate comprehensive `.md` engineering specifications instead of JSON plans, aligning with a structured agent workflow where specs serve as executable blueprints for downstream implementation agents.

## Key Improvements

- **Output Format**: Changed from JSON to detailed Markdown specs saved to `docs/specs/` with 7 mandatory sections
- **Resource Mapping**: Added explicit codebase resource awareness showing existing files (patterns to follow), files to create, and files to modify
- **Architectural Rationale**: Introduced "Rationale & Design Decisions" section explaining WHY the approach was chosen, alternatives considered, and precedent in the codebase
- **Code Skeletons**: Embedded compilable TypeScript code for every layer (Prisma models, Zod schemas with extracted enums, Service classes, tRPC routers, frontend hooks, components, toast utilities, test structures)
- **Execution Plan**: Explicit step-by-step execution order with dependencies
- **Quality Checklist**: Added pre-output validation checklist ensuring resource awareness, complete code skeletons, rationale, and executability

## Alignment with Project Standards

The changes demonstrate excellent adherence to the project's conventions:
- Follows Router→Service pattern
- Zod schemas as source of truth with extracted `as const` enum arrays
- Temporal activity patterns (READ-ONLY + tRPC internal caller)
- Frontend patterns (< 150 lines, logic in hooks, toast utilities)
- TDD workflow (tests before implementation)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects that this is a non-breaking documentation enhancement to an AI skill. The change transforms the skill's output format from JSON to detailed Markdown specs with comprehensive code examples, resource mapping, and architectural rationale. Only issue is a minor reference path typo (cognobserve → ducsigr). No runtime code affected, excellent alignment with project conventions.
- Fix the reference path typo on line 702 before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .claude/skills/senior-architect/SKILL.md | Transformed JSON plan output into detailed .md engineering spec format with code skeletons, resource mapping, architectural rationale, and comprehensive implementation guide - excellent alignment with project conventions |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SeniorArchitect as Senior Architect Skill
    participant Codebase as Existing Codebase
    participant Spec as Spec Output (.md)
    participant ExecutorAgent as Downstream Executor

    User->>SeniorArchitect: Request feature design (e.g., /plan feature)
    
    Note over SeniorArchitect: Phase 1: Requirements & Exploration
    SeniorArchitect->>User: Clarify ambiguous requirements
    User-->>SeniorArchitect: Provide clarifications
    SeniorArchitect->>Codebase: Explore similar patterns
    Codebase-->>SeniorArchitect: Return existing routers, schemas, hooks
    SeniorArchitect->>Codebase: Map related resources
    Codebase-->>SeniorArchitect: Identify files to create/modify
    
    Note over SeniorArchitect: Phase 2: Architecture Design
    SeniorArchitect->>SeniorArchitect: Apply Ducsigr conventions<br/>(Router→Service, Zod schemas, etc.)
    SeniorArchitect->>SeniorArchitect: Consider alternatives<br/>(rationale section)
    SeniorArchitect->>SeniorArchitect: Design database schema
    SeniorArchitect->>SeniorArchitect: Generate code skeletons<br/>(Prisma, Zod, Service, Router, Hook, Component)
    
    Note over SeniorArchitect: Phase 3: Spec Generation
    SeniorArchitect->>Spec: Write .md engineering spec to docs/specs/
    Note over Spec: Includes:<br/>1. Overview<br/>2. Resource Map<br/>3. Rationale<br/>4. DB Schema<br/>5. API Layer (code skeletons)<br/>6. Frontend Layer (code skeletons)<br/>7. Tests<br/>8. Execution Order
    
    SeniorArchitect->>User: Present spec for approval
    User->>SeniorArchitect: Approve or request adjustments
    alt Adjustments needed
        SeniorArchitect->>Spec: Revise spec
        SeniorArchitect->>User: Present updated spec
    end
    
    Note over User,ExecutorAgent: Phase 4: Execution (downstream)
    User->>ExecutorAgent: /execute or /create-ticket
    ExecutorAgent->>Spec: Read .md engineering spec
    Spec-->>ExecutorAgent: Provide:<br/>- Codebase resource map<br/>- Compilable code skeletons<br/>- Execution order<br/>- Test patterns
    ExecutorAgent->>Codebase: Implement per spec<br/>(Step 1: DB schema + migration<br/>Step 2: Zod schemas<br/>Step 3: Write tests<br/>Step 4-9: Service, Router, Hook, Components)

```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->